### PR TITLE
Replacing the chart shortcode with a custom markdown block.

### DIFF
--- a/GlogGenerator/MarkdownExtensions/FencedDataBlock.cs
+++ b/GlogGenerator/MarkdownExtensions/FencedDataBlock.cs
@@ -1,0 +1,40 @@
+﻿using System.Collections.Generic;
+using Markdig.Helpers;
+using Markdig.Parsers;
+using Markdig.Syntax;
+
+namespace GlogGenerator.MarkdownExtensions
+{
+    public class FencedDataBlock : LeafBlock, IFencedBlock
+    {
+        public Dictionary<string, object> Data { get; set; } = new Dictionary<string, object>();
+
+        public char FencedChar { get; set; }
+
+        public int OpeningFencedCharCount { get; set; }
+
+        public StringSlice TriviaAfterFencedChar { get; set; }
+
+        public string Info { get; set; }
+
+        public StringSlice UnescapedInfo { get; set; }
+
+        public StringSlice TriviaAfterInfo { get; set; }
+
+        public string Arguments { get; set; }
+
+        public StringSlice UnescapedArguments { get; set; }
+
+        public StringSlice TriviaAfterArguments { get; set; }
+
+        public NewLine InfoNewLine { get; set; }
+
+        public StringSlice TriviaBeforeClosingFence { get; set; }
+
+        public int ClosingFencedCharCount { get; set; }
+
+        public FencedDataBlock(BlockParser parser) : base(parser)
+        {
+        }
+    }
+}

--- a/GlogGenerator/MarkdownExtensions/FencedDataBlockParser.cs
+++ b/GlogGenerator/MarkdownExtensions/FencedDataBlockParser.cs
@@ -1,0 +1,62 @@
+﻿using System.Text;
+using Markdig.Helpers;
+using Markdig.Parsers;
+using Markdig.Syntax;
+
+namespace GlogGenerator.MarkdownExtensions
+{
+    public class FencedDataBlockParser : FencedBlockParserBase<FencedDataBlock>
+    {
+        public FencedDataBlockParser() : base()
+        {
+            OpeningCharacters = new char[] { ':' };
+        }
+
+        protected override FencedDataBlock CreateFencedBlock(BlockProcessor processor)
+        {
+            return new FencedDataBlock(this);
+        }
+
+        public override BlockState TryContinue(BlockProcessor processor, Block block)
+        {
+            var result = base.TryContinue(processor, block);
+            if (result == BlockState.Continue)
+            {
+                var slice = processor.Line;
+
+                var dataKeyBuilder = new StringBuilder();
+                var hitKvSeparator = false;
+                var dataValueBuilder = new StringBuilder();
+                var c = slice.CurrentChar;
+                while (c != '\0')
+                {
+                    if (!hitKvSeparator && c == ':')
+                    {
+                        hitKvSeparator = true;
+                    }
+                    else if (!hitKvSeparator)
+                    {
+                        dataKeyBuilder.Append(c);
+                    }
+                    else
+                    {
+                        dataValueBuilder.Append(c);
+                    }
+
+                    c = slice.NextChar();
+                }
+
+                if (dataValueBuilder.Length > 0)
+                {
+                    var dataKey = dataKeyBuilder.ToString();
+                    var dataValue = dataValueBuilder.ToString();
+
+                    var dataBlock = block as FencedDataBlock;
+                    dataBlock.Data[dataKey.Trim()] = dataValue.Trim();
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/GlogGenerator/MarkdownExtensions/FencedDataBlockRenderer.cs
+++ b/GlogGenerator/MarkdownExtensions/FencedDataBlockRenderer.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Web;
+using GlogGenerator.HugoCompat;
+using GlogGenerator.RenderState;
+using Markdig.Renderers;
+using Markdig.Renderers.Html;
+using Markdig.Syntax;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace GlogGenerator.MarkdownExtensions
+{
+    public class FencedDataBlockRenderer : HtmlObjectRenderer<FencedDataBlock>
+    {
+        private readonly SiteState siteState;
+        private readonly PageState pageState;
+
+        public FencedDataBlockRenderer(
+            SiteState siteState,
+            PageState pageState)
+        {
+            this.siteState = siteState;
+            this.pageState = pageState;
+        }
+
+        protected override void Write(HtmlRenderer renderer, FencedDataBlock obj)
+        {
+            if (obj.Info.Equals("chart", StringComparison.Ordinal))
+            {
+                var namedArgs = obj.Data.ToDictionary(kv => kv.Key, kv => kv.Value.ToString().Trim('"'));
+
+                var datafileArg = namedArgs["datafile"].ToString();
+                var chartDatafilePath = this.siteState.PathResolver.Resolve(datafileArg);
+                var chartDatafileContent = File.ReadAllText(chartDatafilePath);
+
+                // We need to escape the JSON data, to make it safe for JavaScript to load as a string.
+                var chartDatafileJson = JObject.Parse(chartDatafileContent);
+                var chartDatafileJsonString = JsonConvert.SerializeObject(chartDatafileJson, Formatting.None);
+                var chartDataString = HttpUtility.JavaScriptStringEncode(chartDatafileJsonString);
+
+                string chartType;
+                if (namedArgs.TryGetValue("type", out var chartTypeArg))
+                {
+                    chartType = chartTypeArg.ToString();
+                }
+                else
+                {
+                    chartType = "BarChart";
+                }
+
+                var chartOptionsPairs = namedArgs.Where(kv => !kv.Key.Equals("datafile", StringComparison.OrdinalIgnoreCase) && !kv.Key.Equals("type", StringComparison.OrdinalIgnoreCase));
+                var chartOptionsTextBuilder = new StringBuilder();
+                foreach (var chartOptionsPair in chartOptionsPairs.ToImmutableSortedDictionary())
+                {
+                    // FIXME: instead of using string-encoded JSON in the markup, ... use JSON!
+                    var valueIsJson = chartOptionsPair.Value.ToString().StartsWith('{') || chartOptionsPair.Value.ToString().StartsWith('[');
+                    var optionKey = chartOptionsPair.Key;
+                    string optionValue;
+                    if (valueIsJson)
+                    {
+                        // The raw value has escaped quotation marks, we need to un-escape them.
+                        optionValue = chartOptionsPair.Value.ToString().Replace("\\\"", "\"");
+                    }
+                    else
+                    {
+                        // The raw value needs to be quoted.
+                        optionValue = $"'{chartOptionsPair.Value}'";
+                    }
+
+                    chartOptionsTextBuilder.AppendLine();
+                    chartOptionsTextBuilder.AppendLine();
+                    chartOptionsTextBuilder.AppendLine(CultureInfo.InvariantCulture, $"\toptions['{optionKey}'] = {optionValue};");
+                    chartOptionsTextBuilder.AppendLine();
+                }
+
+#pragma warning disable CA5351 // Yeah MD5 is cryptographically insecure; this isn't security!
+                var pageHashInBytes = Encoding.UTF8.GetBytes(this.pageState.Permalink);
+                var pageHashOutBytes = MD5.HashData(pageHashInBytes);
+                var pageHash = Convert.ToHexString(pageHashOutBytes);
+
+                var chartHashInString = JsonConvert.SerializeObject(namedArgs);
+                var chartHashInBytes = Encoding.UTF8.GetBytes(chartHashInString);
+                var chartHashOutBytes = MD5.HashData(chartHashInBytes);
+                var chartHash = Convert.ToHexString(chartHashOutBytes);
+#pragma warning restore CA5351
+
+                var chartMarkup = $@"<script type=""text/javascript"">
+function drawChart_{pageHash}_{chartHash}() {{
+	var data = new google.visualization.DataTable(""{chartDataString}"");
+	var options = {{}};
+{chartOptionsTextBuilder.ToString()}
+	var element = document.getElementById(""chart_{pageHash}_{chartHash}"");
+	var chart = new google.visualization.{chartType}(element);
+	chart.draw(data, options);
+}}
+</script>
+<noscript><i>A Google Chart would go here, but JavaScript is disabled.</i></noscript>
+<div class=""center""><chart id=""chart_{pageHash}_{chartHash}"" callback=""drawChart_{pageHash}_{chartHash}""></chart></div>";
+
+                renderer.Write(chartMarkup);
+            }
+        }
+    }
+}

--- a/GlogGenerator/MarkdownExtensions/GlogMarkdownExtension.cs
+++ b/GlogGenerator/MarkdownExtensions/GlogMarkdownExtension.cs
@@ -9,11 +9,14 @@ namespace GlogGenerator.MarkdownExtensions
     public class GlogMarkdownExtension : IMarkdownExtension
     {
         private readonly SiteState siteState;
+        private readonly PageState pageState;
 
         public GlogMarkdownExtension(
-            SiteState siteState)
+            SiteState siteState,
+            PageState pageState)
         {
             this.siteState = siteState;
+            this.pageState = pageState;
         }
 
         public void Setup(MarkdownPipelineBuilder pipeline)
@@ -25,6 +28,8 @@ namespace GlogGenerator.MarkdownExtensions
             pipeline.InlineParsers.TryRemove<LinkInlineParser>();
             pipeline.InlineParsers.AddIfNotAlready(new GlogLinkInlineParser(this.siteState));
 
+            pipeline.BlockParsers.AddIfNotAlready<FencedDataBlockParser>();
+
             // The built-in quote block parser will steal '>' at the beginning of a line.
             // We need a customization to not-steal it when followed by '!' for spoilers.
             pipeline.BlockParsers.TryRemove<QuoteBlockParser>();
@@ -35,6 +40,7 @@ namespace GlogGenerator.MarkdownExtensions
 
         public void Setup(MarkdownPipeline pipeline, IMarkdownRenderer renderer)
         {
+            renderer.ObjectRenderers.AddIfNotAlready(new FencedDataBlockRenderer(this.siteState, this.pageState));
             renderer.ObjectRenderers.AddIfNotAlready<SpoilerRenderer>();
         }
     }

--- a/GlogGenerator/RenderState/PageState.cs
+++ b/GlogGenerator/RenderState/PageState.cs
@@ -135,7 +135,7 @@ namespace GlogGenerator.RenderState
 
             var mdPipeline = new MarkdownPipelineBuilder()
                 .Use<ListExtraExtension>()
-                .Use(new GlogMarkdownExtension(this.siteState))
+                .Use(new GlogMarkdownExtension(this.siteState, this))
                 .Use<MarkdownQuirksMarkdigExtension>()
                 .Build();
             rendered = "\t" + Markdown.ToHtml(rendered, mdPipeline);

--- a/content/post/2018/01/01_2017review.md
+++ b/content/post/2018/01/01_2017review.md
@@ -10,11 +10,21 @@ I'm doing well in recovering from {{% abslink href="2016/01/01/2015-a-shameful-e
 
 But enough boring talk about numbers; let's <i>see</i> the boring numbers!
 
-{{< chart type="ColumnChart" datafile="/data/postsandgames_2017.json" title="Posts and Games" legend="{\"position\": \"bottom\"}" >}}
+:::chart
+type: "ColumnChart"
+datafile: "/data/postsandgames_2017.json"
+title: "Posts and Games"
+legend: "{\"position\": \"bottom\"}"
+:::
 
 That's 78 games for 2017, up from 45 in 2016.  Not too bad!  Although there is the statistical caveat that 2017 included record-setting counts of both game demos, and replays of games I'd played before -- at 10 (12.8%) and <b>18</b> (23.1%), respectively.
 
-{{< chart type="ColumnChart" datafile="/data/demosandreplays_2017.json" title="Games Demoed and Replayed" legend="{\"position\": \"bottom\"}" >}}
+:::chart
+type: "ColumnChart"
+datafile: "/data/demosandreplays_2017.json"
+title: "Games Demoed and Replayed"
+legend: "{\"position\": \"bottom\"}"
+:::
 
 The highlight of those was definitely <game:Borderlands 2> and its DLCs, which have held up pretty well (for the most part; more on this later).  [Ōkami's new HD update](game:Ōkami HD) (still in-progress) has been quite pleasant, too -- it has the same flaws as the original, but with beauty and lightheartedness that really make up for them.  And <game:Prince of Persia: The Sands of Time> was a joy to revisit; its storytelling is still fun and riveting, more than a decade later.
 
@@ -24,7 +34,12 @@ Similarly, revisiting <game:Diablo III> (still in-progress) and the remasters of
 
 Let's look at more numbers!  Counting up IGDB metadata on "game type" e.g. expansions and downloadable content:
 
-{{< chart type="ColumnChart" datafile="/data/gametypes_nomain_2017.json" title="Games by Type (except Main Game)" legend="{\"position\": \"bottom\"}" >}}
+:::chart
+type: "ColumnChart"
+datafile: "/data/gametypes_nomain_2017.json"
+title: "Games by Type (except Main Game)"
+legend: "{\"position\": \"bottom\"}"
+:::
 
 Last year I played a record high number of DLCs, at 15 (19.2%) -- the majority (9 of them) thanks to Borderlands 2.  Past replaying the main four story packs, this was my first time with the five "Headhunter" DLCs, which were, uh, <i>mixed</i>.  [Wattle Gobbler](game:Borderlands 2: The Horrible Hunger of the Ravenous Wattle Gobbler) was a fun excuse to revisit Mr. Torgue, and [Son of Crawmerax](game:Borderlands 2: Sir Hammerlock vs. the Son of Crawmerax) was very pretty, but the rest felt generally janky and missable.
 
@@ -34,7 +49,12 @@ And the other three DLCs were <i>also</i> replays, via BioShock.  It wasn't quit
 
 More numbers: what platforms did I play on?  Actually -- since I know <platform:PC> dominates every year; what <i>other</i> platforms did I play on?
 
-{{< chart type="ColumnChart" datafile="/data/gameplatforms_nopc_2017.json" title="Games by Platform (except PC, and those with zero games in 2017)" legend="{\"position\": \"bottom\"}" >}}
+:::chart
+type: "ColumnChart"
+datafile: "/data/gameplatforms_nopc_2017.json"
+title: "Games by Platform (except PC, and those with zero games in 2017)"
+legend: "{\"position\": \"bottom\"}"
+:::
 
 <i>Eight years later</i>, I've finally put [Bowser's Inside Story](game:Mario & Luigi: Bowser's Inside Story) to rest, formally retiring my <platform:DS> backlog.  And [Breath of the Wild](game:The Legend of Zelda: Breath of the Wild) is certainly the death knell for my <platform:Wii U>.
 
@@ -46,7 +66,13 @@ The <platform:Switch> is a new entry, via <game:Super Mario Odyssey>.  Other tha
 
 Now for something I haven't really tracked before: how much did I actually <i>like</i> what I played?
 
-{{< chart type="ColumnChart" datafile="/data/ratings_2017.json" title="Ratings" colors="[\"gray\", \"red\", \"orange\", \"gold\", \"green\", \"blue\"]" legend="{\"position\": \"bottom\"}" >}}
+:::chart
+type: "ColumnChart"
+datafile: "/data/ratings_2017.json"
+title: "Ratings"
+colors: "[\"gray\", \"red\", \"orange\", \"gold\", \"green\", \"blue\"]"
+legend: "{\"position\": \"bottom\"}"
+:::
 
 Well, the <rating:Awesome> count is on the low side - at 6 (7.7%) - with Breath of the Wild being the standout of the year.  But plenty of <rating:Good>s, at 26 (33.3%).  That's, uh... that's good.  &#x1F44D;
 

--- a/content/post/2019/01/01_2018review.md
+++ b/content/post/2019/01/01_2018review.md
@@ -28,13 +28,23 @@ As for the other four titles, they appear to still be plodding along.
 
 On the subject of year-on-year disappointment -- let's look at the Glog stats from 2018!
 
-{{< chart type="ColumnChart" datafile="/data/postsandgames_2018.json" title="Posts and Games" legend="{\"position\": \"bottom\"}" >}}
+:::chart
+type: "ColumnChart"
+datafile: "/data/postsandgames_2018.json"
+title: "Posts and Games"
+legend: "{\"position\": \"bottom\"}"
+:::
 
 2017's games-played count was pretty high, and I failed to reach that same bar in 2018.  But, hey, not bad.
 
 A lot of that 2017 count came from replays, including remasters.  And even though one of each (<game:Ōkami HD> and <game:Diablo III>) carried over into 2018, I didn't end up replaying much, last year.
 
-{{< chart type="ColumnChart" datafile="/data/demosandreplays_2018.json" title="Games Demoed and Replayed" legend="{\"position\": \"bottom\"}" >}}
+:::chart
+type: "ColumnChart"
+datafile: "/data/demosandreplays_2018.json"
+title: "Games Demoed and Replayed"
+legend: "{\"position\": \"bottom\"}"
+:::
 
 Reiterating my previous praise, Ōkami's HD facelift was <b>gorgeous</b>, and its beauty really helped overcome some of the game's more awkward components.
 
@@ -50,7 +60,12 @@ And <game:Portal 2> is still good.  Not as revolutionary as back in 2011, but Ca
 
 On to DLCs.  My 2017 included a lot of them, largely thanks to <game:Borderlands 2>; 2018 was more tame, although still substantial.
 
-{{< chart type="ColumnChart" datafile="/data/gametypes_nomain_2018.json" title="Games by Type (except Main Game)" legend="{\"position\": \"bottom\"}" >}}
+:::chart
+type: "ColumnChart"
+datafile: "/data/gametypes_nomain_2018.json"
+title: "Games by Type (except Main Game)"
+legend: "{\"position\": \"bottom\"}"
+:::
 
 I guess that <game:Thronebreaker: The Witcher Tales> is considered a "Standalone Expansion" for the [Gwent](game:Gwent: The Witcher Card Game) digital CCG.  Thronebreaker was pretty great, albeit lacking the narrative heft of Geralt's own adventures.
 
@@ -70,7 +85,12 @@ Moving on to platform variety...
 
 In 2017 I played games on seven different platforms, retiring my <platform:DS> and <platform:Wii U>.  My platform activity in 2018 was less varied, covering only four, including the ever-predominant PC.
 
-{{< chart type="ColumnChart" datafile="/data/gameplatforms_nopc_2018.json" title="Games by Platform (except PC, and those with zero games in 2018)" legend="{\"position\": \"bottom\"}" >}}
+:::chart
+type: "ColumnChart"
+datafile: "/data/gameplatforms_nopc_2018.json"
+title: "Games by Platform (except PC, and those with zero games in 2018)"
+legend: "{\"position\": \"bottom\"}"
+:::
 
 <game:Paper Mario: Sticker Star> was almost certainly the last thing my <platform:3DS> will ever see.  Not a great send-off, unfortunately.  But, the system overall had a pretty good run.
 
@@ -80,7 +100,13 @@ Something that stands out about this graph is the <i>lack</i> of <platform:Switc
 
 Speaking of Odyssey, it was one of fairly few games that I rated "<rating:Awesome>" in 2017.  In 2018, despite playing less games overall, more of them felt Awesome to me.
 
-{{< chart type="ColumnChart" datafile="/data/ratings_2018.json" title="Ratings" colors="[\"gray\", \"red\", \"orange\", \"gold\", \"green\", \"blue\"]" legend="{\"position\": \"bottom\"}" >}}
+:::chart
+type: "ColumnChart"
+datafile: "/data/ratings_2018.json"
+title: "Ratings"
+colors: "[\"gray\", \"red\", \"orange\", \"gold\", \"green\", \"blue\"]"
+legend: "{\"position\": \"bottom\"}"
+:::
 
 <game:Middle-earth: Shadow of War>, like its predecessor, wasn't revolutionary but was a shit-ton of orc-murderin' fun.  [Prey](game:Prey (2017)) had some imperfections and annoyances, but blew me away with its mechanical depth and interactive world.  <game:Horizon Zero Dawn> needed a better inventory system, but had plenty of thrilling combat, and an <i>amazing</i> story.
 

--- a/content/post/2020/01/01_2019review.md
+++ b/content/post/2020/01/01_2019review.md
@@ -6,11 +6,21 @@ category = ["Site News"]
 
 2019 was a stressful year, and my gaming activity - a relative decline from 2017 and 2018 - reflects that.
 
-{{< chart type="ColumnChart" datafile="/data/postsandgames_2019.json" title="Posts and Games" legend="{\"position\": \"bottom\"}" >}}
+:::chart
+type: "ColumnChart"
+datafile: "/data/postsandgames_2019.json"
+title: "Posts and Games"
+legend: "{\"position\": \"bottom\"}"
+:::
 
 Especialy when considering how many of my 2019 posts were about demos: in 2017, demos accounted for 13% (10/78) of the games I played; in 2018, 8% (5/59); and in 2019, 22% (9/41).
 
-{{< chart type="ColumnChart" datafile="/data/demosandreplays_2019.json" title="Games Demoed and Replayed" legend="{\"position\": \"bottom\"}" >}}
+:::chart
+type: "ColumnChart"
+datafile: "/data/demosandreplays_2019.json"
+title: "Games Demoed and Replayed"
+legend: "{\"position\": \"bottom\"}"
+:::
 
 I mean, maybe it's cool that I played more post-worthy demos last year, but <i>less non-demos</i> is a worrying trend.
 
@@ -28,7 +38,12 @@ My replay count was relatively stable, including both remasters and booting up o
 
 Expansions and DLC were almost a non-issue in 2019:
 
-{{< chart type="ColumnChart" datafile="/data/gametypes_nomain_2019.json" title="Games by Type (except Main Game)" legend="{\"position\": \"bottom\"}" >}}
+:::chart
+type: "ColumnChart"
+datafile: "/data/gametypes_nomain_2019.json"
+title: "Games by Type (except Main Game)"
+legend: "{\"position\": \"bottom\"}"
+:::
 
 * I'm glad that I got around to Breath of the Wild's DLCs, or at least [The Champions' Ballad](game:The Legend of Zelda: Breath of the Wild - The Champions' Ballad) chapter; [The Master Trials](game:The Legend of Zelda: Breath of the Wild - The Master Trials) I could have done without.
 
@@ -38,7 +53,12 @@ Expansions and DLC were almost a non-issue in 2019:
 
 The platforms I played on in 2019 were <i>mostly</i> unremarkable, with <platform:PC> - like always - occupying the lion's share of my time.  As for the rest:
 
-{{< chart type="ColumnChart" datafile="/data/gameplatforms_nopc_2019.json" title="Games by Platform (except PC, and those with zero games in 2019)" legend="{\"position\": \"bottom\"}" >}}
+:::chart
+type: "ColumnChart"
+datafile: "/data/gameplatforms_nopc_2019.json"
+title: "Games by Platform (except PC, and those with zero games in 2019)"
+legend: "{\"position\": \"bottom\"}"
+:::
 
 My historic <platform:Xbox One> usage has been staggeringly low, since its library overlaps so much with PC; last year's <game:Crackdown 3> is in rare company.  The game was overall competent and fun, but not very compelling and definitely not innovative.  (With apologies to Terry Crews, who is undoubtedly the game's best new feature.)
 
@@ -50,7 +70,13 @@ What's <i>interesting</i> on that chart isn't the sparse wasteland that is my no
 
 Unfortunately, the total number of games that really knocked my socks off in 2019 was pretty low.
 
-{{< chart type="ColumnChart" datafile="/data/ratings_2019.json" title="Ratings" colors="[\"gray\", \"red\", \"orange\", \"gold\", \"green\", \"blue\"]" legend="{\"position\": \"bottom\"}" >}}
+:::chart
+type: "ColumnChart"
+datafile: "/data/ratings_2019.json"
+title: "Ratings"
+colors: "[\"gray\", \"red\", \"orange\", \"gold\", \"green\", \"blue\"]"
+legend: "{\"position\": \"bottom\"}"
+:::
 
 Of the year's five "<rating:Awesome>" games, <i>three</i> were games I'd <i>already played</i>!  ([Breath of the Wild](game:The Legend of Zelda: Breath of the Wild), the [Phoenix Wright trilogy](game:Phoenix Wright: Ace Attorney Trilogy), and <game:Chrono Trigger>.)
 

--- a/content/post/2021/01/01_2020review.md
+++ b/content/post/2021/01/01_2020review.md
@@ -8,7 +8,12 @@ Well, we made it.  <i>Phew.</i>
 
 Aside from the ... everything, 2020 was actually a great year for the Glog.  In January I resolved to aggressively tackle my backlog, and I ended up doing a damned good job of it; a couple more years like this might actually clear it out!
 
-{{< chart type="ColumnChart" datafile="/data/postsandgames_2020.json" title="Posts and Games" legend="{\"position\": \"bottom\"}" >}}
+:::chart
+type: "ColumnChart"
+datafile: "/data/postsandgames_2020.json"
+title: "Posts and Games"
+legend: "{\"position\": \"bottom\"}"
+:::
 
 Last year saw the second-highest number of games Glogged since I started counting -- and that's only the number of games I "bothered" to write about.
 
@@ -16,7 +21,15 @@ I don't have a firm count of how many I gave up on without a post, but I will sa
 
 The dark side of backlog-busting is that many of those games sat unplayed for a reason - more on that in a bit - and, for palate-cleansing purposes, my 2020 gaming also included a significant amount of replaying old favorites.
 
-{{< chart type="AreaChart" datafile="/data/demosandreplays_2020.json" title="Games Demoed and Replayed" legend="{\"position\": \"bottom\"}" isStacked="percent" pointSize="5" focusTarget="category" >}}
+:::chart
+type: "AreaChart"
+datafile: "/data/demosandreplays_2020.json"
+title: "Games Demoed and Replayed"
+legend: "{\"position\": \"bottom\"}"
+isStacked: "percent"
+pointSize: 5
+focusTarget: "category"
+:::
 
 <game:Grand Theft Auto IV> / [Ballad of Gay Tony](game:Grand Theft Auto IV: The Ballad of Gay Tony) / [V](game:Grand Theft Auto V), <game:Batman: Arkham Origins> / [Asylum](game:Batman: Arkham Asylum) / [City](game:Batman: Arkham City) / [Harley Quinn's Revenge](game:Batman: Arkham City - Harley Quinn's Revenge) / [Knight](game:Batman: Arkham Knight), and [Uncharted 2](game:Uncharted 2: Among Thieves) / [3](game:Uncharted 3: Drake's Deception) / [4](game:Uncharted 4: A Thief's End) / [Lost Legacy](game:Uncharted: The Lost Legacy) account for the bulk of said replays.
 
@@ -28,7 +41,15 @@ On that note, it was very satisfying to see Steam evangelizing demos in its <a h
 
 As for DLC and expansion activity, those replays ended up feeding a big chunk of it...
 
-{{< chart type="AreaChart" datafile="/data/gametypes_2020.json" title="Games by Type" legend="{\"position\": \"bottom\"}" isStacked="percent" pointSize="5" focusTarget="category" >}}
+:::chart
+type: "AreaChart"
+datafile: "/data/gametypes_2020.json"
+title: "Games by Type"
+legend: "{\"position\": \"bottom\"}"
+isStacked: "percent"
+pointSize: 5
+focusTarget: "category"
+:::
 
 ... between the aforementioned Ballad of Gay Tony, Harley Quinn's Revenge, and Lost Legacy replays.  Last year also saw my <i>first</i> playthroughs of some Batman DLCs, specifically the better-than-expected [Cold, Cold Heart](game:Batman: Arkham Origins - Cold, Cold Heart), the <i>worse</i>-than-expected [A Matter of Family](game:Batman: Arkham Knight - A Matter of Family), and the pretty-much-just-as-expected [Season of Infamy: Most Wanted Expansion](game:Batman: Arkham Knight - Season of Infamy: Most Wanted Expansion).
 
@@ -40,7 +61,16 @@ My one non-PC, non-replay game of 2020 was the <game:Final Fantasy VII Remake> d
 
 Now, a few paragraphs ago, I said that the "dark side" of spelunking into my backlog was that many games were there "for a reason."  If I was being generous, I could say the reason was that they didn't quite stand out from their competitors; but if I was being <i>real</i>, I'd say that many just <i>weren't good</i>.
 
-{{< chart type="AreaChart" datafile="/data/ratings_2020.json" title="Ratings" colors="[\"gray\", \"red\", \"orange\", \"gold\", \"green\", \"blue\"]" legend="{\"position\": \"bottom\"}" isStacked="percent" pointSize="5" focusTarget="category" >}}
+:::chart
+type: "AreaChart"
+datafile: "/data/ratings_2020.json"
+title: "Ratings"
+colors: "[\"gray\", \"red\", \"orange\", \"gold\", \"green\", \"blue\"]"
+legend: "{\"position\": \"bottom\"}"
+isStacked: "percent"
+pointSize: 5
+focusTarget: "category"
+:::
 
 My game ratings for 2020 were significantly biased toward "No Rating" (which sometimes just means I'm being polite) and <rating:Meh>, with a record-low proportion of <rating:Good> or <rating:Awesome> ratings.
 

--- a/content/post/2022/01/01_2021review.md
+++ b/content/post/2022/01/01_2021review.md
@@ -10,13 +10,26 @@ category = ["Site News"]
 
 Not all of that catching-up made it into the Glog -- more and more, I'm rapidly trying and discarding games, without wasting time on write-ups.  (I'll get to the <i>hard data</i> on that later.)
 
-{{< chart type="ColumnChart" datafile="/data/postsandgames_2021.json" title="Posts and Games" legend="{\"position\": \"bottom\"}" >}}
+:::chart
+type: "ColumnChart"
+datafile: "/data/postsandgames_2021.json"
+title: "Posts and Games"
+legend: "{\"position\": \"bottom\"}"
+:::
 
 In fact, 2021 saw my {{% abslink href="2021/09/06/dismissable-content/" %}}first multi-game post!{{% /abslink %}}, resulting in <i>more games played than posts written</i> for the first time in Glog history (ooh, ahh).  I consider that a good omen for my future gaming activity: less writing, more playing!
 
 Anyway, my continued focus on backlog-busting also meant I paid less attention than ever to demos (<game:Copy Editor> being the sole exception), although ...
 
-{{< chart type="AreaChart" datafile="/data/demosandreplays_2021.json" title="Games Demoed and Replayed" legend="{\"position\": \"bottom\"}" isStacked="percent" pointSize="5" focusTarget="category" >}}
+:::chart
+type: "AreaChart"
+datafile: "/data/demosandreplays_2021.json"
+title: "Games Demoed and Replayed"
+legend: "{\"position\": \"bottom\"}"
+isStacked: "percent"
+pointSize: 5
+focusTarget: "category"
+:::
 
 ... just as in 2020, I did feel a frequent need to cleanse my palate, by replaying known-good games.
 
@@ -28,7 +41,15 @@ Setting aside <game:Darksiders II> and [Deadly Premonition](game:Deadly Premonit
 
 Coincidentally, one side-effect of replaying those particular games (Mass Effect 2, especially) was the <b>most DLCs and expansions I've played in one year</b>:
 
-{{< chart type="AreaChart" datafile="/data/gametypes_2021.json" title="Games by Type" legend="{\"position\": \"bottom\"}" isStacked="percent" pointSize="5" focusTarget="category" >}}
+:::chart
+type: "AreaChart"
+datafile: "/data/gametypes_2021.json"
+title: "Games by Type"
+legend: "{\"position\": \"bottom\"}"
+isStacked: "percent"
+pointSize: 5
+focusTarget: "category"
+:::
 
 I've already mentioned Saints Row 3's DLCs, and Horizon's Frozen Wilds; then there were Mass Effect's [Bring Down the Sky](game:Mass Effect: Bring Down the Sky), and Mass Effect 2's [Zaeed - The Price of Revenge](game:Mass Effect 2: Zaeed - The Price of Revenge), [Kasumi - Stolen Memory](game:Mass Effect 2: Kasumi - Stolen Memory), [Firewalker Pack](game:Mass Effect 2: Firewalker Pack), [Overlord](game:Mass Effect 2: Overlord), [Lair of the Shadow Broker](game:Mass Effect 2: Lair of the Shadow Broker), and [Arrival](game:Mass Effect 2: Arrival) (phew!) ... which were all pretty underwhelming, and never struck me as critical to the overall Mass Effect epic.
 
@@ -44,7 +65,16 @@ Which might be my last PS4 game, depending on how the upcoming [God of War](game
 
 But if this is the end for my PS4, then it's going out with a "bang," as Ghost of Tsushima ranks among the small number of <rating:Awesome> games I played in 2021.
 
-{{< chart type="AreaChart" datafile="/data/ratings_2021.json" title="Ratings" colors="[\"gray\", \"red\", \"orange\", \"gold\", \"green\", \"blue\"]" legend="{\"position\": \"bottom\"}" isStacked="percent" pointSize="5" focusTarget="category" >}}
+:::chart
+type: "AreaChart"
+datafile: "/data/ratings_2021.json"
+title: "Ratings"
+colors: "[\"gray\", \"red\", \"orange\", \"gold\", \"green\", \"blue\"]"
+legend: "{\"position\": \"bottom\"}"
+isStacked: "percent"
+pointSize: 5
+focusTarget: "category"
+:::
 
 That ranking also includes:
 

--- a/content/post/2023/01/01_2022review.md
+++ b/content/post/2023/01/01_2022review.md
@@ -14,9 +14,22 @@ Steam launched a year-in-review feature called <a href="https://store.steampower
 
 As does comparing Steam's counters with Glog statistics:
 
-{{< chart type="ColumnChart" datafile="/data/postsandgames_2022.json" title="Posts and Games" legend="{\"position\": \"bottom\"}" >}}
+:::chart
+type: "ColumnChart"
+datafile: "/data/postsandgames_2022.json"
+title: "Posts and Games"
+legend: "{\"position\": \"bottom\"}"
+:::
 
-{{< chart type="AreaChart" datafile="/data/demosandreplays_2022.json" title="Games Demoed and Replayed" legend="{\"position\": \"bottom\"}" isStacked="percent" pointSize="5" focusTarget="category" >}}
+:::chart
+type: "AreaChart"
+datafile: "/data/demosandreplays_2022.json"
+title: "Games Demoed and Replayed"
+legend: "{\"position\": \"bottom\"}"
+isStacked: "percent"
+pointSize: 5
+focusTarget: "category"
+:::
 
 <i>Where did all those Steam games and demos go?</i>  Well, <b>nowhere</b>.
 
@@ -26,7 +39,15 @@ As for those replays: I dug up [Assassin's Creed IV](game:Assassin's Creed IV Bl
 
 ... anyway.  My DLC and expansion activity in 2022 tells a similar story:
 
-{{< chart type="AreaChart" datafile="/data/gametypes_2022.json" title="Games by Type" legend="{\"position\": \"bottom\"}" isStacked="percent" pointSize="5" focusTarget="category" >}}
+:::chart
+type: "AreaChart"
+datafile: "/data/gametypes_2022.json"
+title: "Games by Type"
+legend: "{\"position\": \"bottom\"}"
+isStacked: "percent"
+pointSize: 5
+focusTarget: "category"
+:::
 
 While it'd be hard to beat the <i>quantity</i> of DLCs (especially <tag:Mass Effect>'s) I played in 2021, last year's <i>quality</i> of add-ons was surprisingly solid.
 
@@ -36,7 +57,16 @@ While it'd be hard to beat the <i>quantity</i> of DLCs (especially <tag:Mass Eff
 
 These add-ons were <i>good</i>, just like the main games I played last year.  I mean, check out these rating values:
 
-{{< chart type="AreaChart" datafile="/data/ratings_2022.json" title="Ratings" colors="[\"gray\", \"red\", \"orange\", \"gold\", \"green\", \"blue\"]" legend="{\"position\": \"bottom\"}" isStacked="percent" pointSize="5" focusTarget="category" >}}
+:::chart
+type: "AreaChart"
+datafile: "/data/ratings_2022.json"
+title: "Ratings"
+colors: "[\"gray\", \"red\", \"orange\", \"gold\", \"green\", \"blue\"]"
+legend: "{\"position\": \"bottom\"}"
+isStacked: "percent"
+pointSize: 5
+focusTarget: "category"
+:::
 
 Here, summarily, is the glorious result of my ruthless backlog management.  A <i>majority</i> - more than half! - of my post ratings were positive, for the first time since 2015 (which was itself a {{% abslink href="2016/01/01/2015-a-shameful-embarrassment-of-statistical-failure/" %}}statistical aberration{{% /abslink %}}).
 


### PR DESCRIPTION
"FencedData" can, kinda, be extended to any element type which requires inline data details to be recognized and rendered by the site-builder.  (Contrast with e.g. the fenced "code" block, which is simply parsed and annotated at build-time, then rendered largely as-is for client-side decoration.)