### PR TITLE
Markdown roundtrip rendering: Glog content can now be rewritten, consistently.

### DIFF
--- a/.github/workflows/UpdateDataAndBuildAndDeploy.yml
+++ b/.github/workflows/UpdateDataAndBuildAndDeploy.yml
@@ -37,6 +37,7 @@ jobs:
           rm -rf public
           ./GlogGeneratorBuild/GlogGenerator build -i . -t GlogGeneratorBuild/templates -u true --igdb-client-id jy5t8x2w2eqdc7bax2zx3rlne7eup4 --igdb-client-secret $TWITCH_CLIENT_SECRET -h "https://tsuereth.com" -o public
 
+      # TODO: Reimplement to allow multiple files, if source data has changed!
       - name: CommitDataUpdates
         env:
           BRANCH: ${{ github.head_ref || github.ref }}

--- a/GlogGenerator.Test/Data/PostDataTests.cs
+++ b/GlogGenerator.Test/Data/PostDataTests.cs
@@ -1,5 +1,7 @@
 using System.IO;
 using GlogGenerator.Data;
+using GlogGenerator.MarkdownExtensions;
+using Markdig;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace GlogGenerator.Test.Data
@@ -18,9 +20,21 @@ namespace GlogGenerator.Test.Data
             Assert.AreEqual("2023/07/23/re-climbing-the-orc-chart/", testPostData.PermalinkRelative);
         }
 
-        [Ignore]
         [TestMethod]
-        public void TestToMarkdownString()
+        public void TestToMarkdownStringSimple()
+        {
+            var testPostFilePath = Path.Combine(Directory.GetCurrentDirectory(), "TestFiles", "Data", "PostDataTests", "testpostdata.md");
+            var testPostFileText = File.ReadAllText(testPostFilePath);
+
+            var builder = new SiteBuilder();
+            var testPostData = PostData.MarkdownFromFilePath(builder.GetMarkdownPipeline(), testPostFilePath);
+            var testPostToString = testPostData.ToMarkdownString(builder.GetMarkdownPipeline());
+
+            Assert.AreEqual(testPostFileText, testPostToString);
+        }
+
+        [TestMethod]
+        public void TestToMarkdownStringComplex()
         {
             var testPostFilePath = Path.Combine(Directory.GetCurrentDirectory(), "TestFiles", "Data", "PostDataTests", "testfenceddatacharts.md");
             var testPostFileText = File.ReadAllText(testPostFilePath);

--- a/GlogGenerator.Test/Data/PostDataTests.cs
+++ b/GlogGenerator.Test/Data/PostDataTests.cs
@@ -20,14 +20,14 @@ namespace GlogGenerator.Test.Data
 
         [Ignore]
         [TestMethod]
-        public void TestToString()
+        public void TestToMarkdownString()
         {
             var testPostFilePath = Path.Combine(Directory.GetCurrentDirectory(), "TestFiles", "Data", "PostDataTests", "testfenceddatacharts.md");
             var testPostFileText = File.ReadAllText(testPostFilePath);
 
             var builder = new SiteBuilder();
             var testPostData = PostData.MarkdownFromFilePath(builder.GetMarkdownPipeline(), testPostFilePath);
-            var testPostToString = testPostData.ToString();
+            var testPostToString = testPostData.ToMarkdownString(builder.GetMarkdownPipeline());
 
             Assert.AreEqual(testPostFileText, testPostToString);
         }

--- a/GlogGenerator.Test/MarkdownExtensions/FencedDataBlockTests.cs
+++ b/GlogGenerator.Test/MarkdownExtensions/FencedDataBlockTests.cs
@@ -1,0 +1,70 @@
+using System.IO;
+using System.Linq;
+using System.Text;
+using GlogGenerator.MarkdownExtensions;
+using Markdig;
+using Markdig.Syntax;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace GlogGenerator.Test.MarkdownExtensions
+{
+    [TestClass]
+    public class FencedDataBlockTests
+    {
+        [TestMethod]
+        public void TestFencedDataBlockParse()
+        {
+            var builder = new SiteBuilder();
+
+            var testText = @":::testitem
+key1: ""value1""
+key2: ""value2""
+:::";
+
+            var mdDoc = Markdown.Parse(testText, builder.GetMarkdownPipeline());
+            var fencedDataBlock = mdDoc.Descendants<FencedDataBlock>().FirstOrDefault();
+
+            Assert.IsNotNull(fencedDataBlock);
+
+            var parsedData = fencedDataBlock.Data;
+            Assert.IsTrue(parsedData.ContainsKey("key1"));
+            Assert.AreEqual("\"value1\"", parsedData["key1"]);
+            Assert.IsTrue(parsedData.ContainsKey("key2"));
+            Assert.AreEqual("\"value2\"", parsedData["key2"]);
+        }
+
+        // TODO?: test HTML rendering
+
+        [TestMethod]
+        public void TestFencedDataBlockNormalize()
+        {
+            var builder = new SiteBuilder();
+
+            var testText = @":::testitem
+key1: ""value1""
+key2: ""value2""
+:::";
+
+            var result = Markdown.Normalize(testText, pipeline: builder.GetMarkdownPipeline());
+
+            Assert.AreEqual(testText, result);
+        }
+
+        [TestMethod]
+        public void TestFencedDataBlockRoundtrip()
+        {
+            var builder = new SiteBuilder();
+
+            var testText = @":::testitem
+key1: ""value1""
+key2: ""value2""
+:::";
+
+            var mdDoc = Markdown.Parse(testText, builder.GetMarkdownPipeline());
+
+            var result = mdDoc.ToMarkdownString(builder.GetMarkdownPipeline());
+
+            Assert.AreEqual(testText, result);
+        }
+    }
+}

--- a/GlogGenerator.Test/MarkdownExtensions/FencedDataBlockTests.cs
+++ b/GlogGenerator.Test/MarkdownExtensions/FencedDataBlockTests.cs
@@ -66,5 +66,27 @@ key2: ""value2""
 
             Assert.AreEqual(testText, result);
         }
+
+        [TestMethod]
+        public void TestFencedDataBlockTwoInARowRoundtrip()
+        {
+            var builder = new SiteBuilder();
+
+            var testText = @":::testitem
+key1: ""value1""
+key2: ""value2""
+:::
+
+:::testitem
+key1: ""value1""
+key2: ""value2""
+:::";
+
+            var mdDoc = Markdown.Parse(testText, builder.GetMarkdownPipeline());
+
+            var result = mdDoc.ToMarkdownString(builder.GetMarkdownPipeline());
+
+            Assert.AreEqual(testText, result);
+        }
     }
 }

--- a/GlogGenerator.Test/MarkdownExtensions/GlogLinkTests.cs
+++ b/GlogGenerator.Test/MarkdownExtensions/GlogLinkTests.cs
@@ -1,0 +1,458 @@
+using System;
+using System.Collections.Generic;
+using GlogGenerator.Data;
+using GlogGenerator.MarkdownExtensions;
+using Markdig;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+
+namespace GlogGenerator.Test.MarkdownExtensions
+{
+    [TestClass]
+    public class GlogLinkTests
+    {
+        private static SiteBuilder PrepareTestSiteBuilder(
+            params IGlogReferenceable[] dataItems)
+        {
+            var logger = new TestLogger();
+
+            var configData = new ConfigData()
+            {
+                BaseURL = "fake://test.url/",
+            };
+
+            var mockSiteDataIndex = Substitute.For<ISiteDataIndex>();
+            var testGames = new List<GameData>();
+            var testPlatforms = new List<PlatformData>();
+            var testTags = new List<TagData>();
+            foreach (var dataItem in dataItems)
+            {
+                if (dataItem is GameData)
+                {
+                    var gameData = dataItem as GameData;
+                    mockSiteDataIndex.GetGame(gameData.Title).Returns(gameData);
+                    testGames.Add(gameData);
+                }
+                else if (dataItem is PlatformData)
+                {
+                    var platformData = dataItem as PlatformData;
+                    mockSiteDataIndex.GetPlatform(platformData.Abbreviation).Returns(platformData);
+                    testPlatforms.Add(platformData);
+                }
+                else if (dataItem is TagData)
+                {
+                    var tagData = dataItem as TagData;
+                    mockSiteDataIndex.GetTag(tagData.Name).Returns(tagData);
+                    testTags.Add(tagData);
+                }
+                else
+                {
+                    throw new NotImplementedException();
+                }
+            }
+
+            mockSiteDataIndex.GetGames().Returns(testGames);
+            mockSiteDataIndex.GetPlatforms().Returns(testPlatforms);
+            mockSiteDataIndex.GetTags().Returns(testTags);
+
+            var builder = new SiteBuilder(
+                logger,
+                configData,
+                mockSiteDataIndex);
+
+            builder.UpdateContentRoutes();
+
+            return builder;
+        }
+
+        [TestMethod]
+        public void TestGlogGameAutolink()
+        {
+            var testGameData = new GameData()
+            {
+                Title = "Test Game: With a Subtitle",
+            };
+
+            var builder = PrepareTestSiteBuilder(
+                testGameData);
+
+            var testText = "Remember <game:Test Game: With a Subtitle>?";
+
+            var result = Markdown.ToHtml(testText, builder.GetMarkdownPipeline());
+
+            Assert.AreEqual("<p>Remember <a href=\"fake://test.url/game/test-game-with-a-subtitle\">Test Game: With a Subtitle</a>?</p>\n", result);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void TestGlogGameAutolinkNotFound()
+        {
+            var builder = PrepareTestSiteBuilder();
+
+            var testText = "Remember <game:Test Game: With a Subtitle>?";
+
+            Markdown.ToHtml(testText, builder.GetMarkdownPipeline());
+        }
+
+        [TestMethod]
+        public void TestGlogGameAutolinkNormalize()
+        {
+            var testGameData = new GameData()
+            {
+                Title = "Test Game: With a Subtitle",
+            };
+
+            var builder = PrepareTestSiteBuilder(
+                testGameData);
+
+            var testText = "Remember <game:Test Game: With a Subtitle>?";
+
+            var result = Markdown.Normalize(testText, pipeline: builder.GetMarkdownPipeline());
+
+            Assert.AreEqual(testText, result);
+        }
+
+        [TestMethod]
+        public void TestGlogGameAutolinkRoundtrip()
+        {
+            var testGameData = new GameData()
+            {
+                Title = "Test Game: With a Subtitle",
+            };
+
+            var builder = PrepareTestSiteBuilder(
+                testGameData);
+
+            var testText = "Remember <game:Test Game: With a Subtitle>?";
+
+            var mdDoc = Markdown.Parse(testText, builder.GetMarkdownPipeline());
+
+            var result = mdDoc.ToMarkdownString(builder.GetMarkdownPipeline());
+
+            Assert.AreEqual(testText, result);
+        }
+
+        [TestMethod]
+        public void TestGlogGameLink()
+        {
+            var testGameData = new GameData()
+            {
+                Title = "Test Game: With a Subtitle",
+            };
+
+            var builder = PrepareTestSiteBuilder(
+                testGameData);
+
+            var testText = "Remember [that game with a stupid subtitle](game:Test Game: With a Subtitle)?";
+
+            var result = Markdown.ToHtml(testText, builder.GetMarkdownPipeline());
+
+            Assert.AreEqual("<p>Remember <a href=\"fake://test.url/game/test-game-with-a-subtitle\">that game with a stupid subtitle</a>?</p>\n", result);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void TestGlogGameLinkNotFound()
+        {
+            var builder = PrepareTestSiteBuilder();
+
+            var testText = "Remember [that game with a stupid subtitle](game:Test Game: With a Subtitle)?";
+
+            Markdown.ToHtml(testText, builder.GetMarkdownPipeline());
+        }
+
+        [TestMethod]
+        public void TestGlogGameLinkNormalize()
+        {
+            var testGameData = new GameData()
+            {
+                Title = "Test Game: With a Subtitle",
+            };
+
+            var builder = PrepareTestSiteBuilder(
+                testGameData);
+
+            var testText = "Remember [that game with a stupid subtitle](game:Test Game: With a Subtitle)?";
+
+            var result = Markdown.Normalize(testText, pipeline: builder.GetMarkdownPipeline());
+
+            Assert.AreEqual(testText, result);
+        }
+
+        [TestMethod]
+        public void TestGlogGameLinkRoundtrip()
+        {
+            var testGameData = new GameData()
+            {
+                Title = "Test Game: With a Subtitle",
+            };
+
+            var builder = PrepareTestSiteBuilder(
+                testGameData);
+
+            var testText = "Remember [that game with a stupid subtitle](game:Test Game: With a Subtitle)?";
+
+            var mdDoc = Markdown.Parse(testText, builder.GetMarkdownPipeline());
+
+            var result = mdDoc.ToMarkdownString(builder.GetMarkdownPipeline());
+
+            Assert.AreEqual(testText, result);
+        }
+
+        [TestMethod]
+        public void TestGlogPlatformAutolink()
+        {
+            var testPlatformData = new PlatformData()
+            {
+                Abbreviation = "GS2",
+                Name = "GlogStation 2",
+            };
+
+            var builder = PrepareTestSiteBuilder(
+                testPlatformData);
+
+            var testText = "There were no good <platform:GS2> games";
+
+            var result = Markdown.ToHtml(testText, builder.GetMarkdownPipeline());
+
+            Assert.AreEqual("<p>There were no good <a href=\"fake://test.url/platform/gs2\">GS2</a> games</p>\n", result);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void TestGlogPlatformAutolinkNotFound()
+        {
+            var builder = PrepareTestSiteBuilder();
+
+            var testText = "There were no good <platform:GS2> games";
+
+            Markdown.ToHtml(testText, builder.GetMarkdownPipeline());
+        }
+
+        [TestMethod]
+        public void TestGlogPlatformAutolinkNormalize()
+        {
+            var testPlatformData = new PlatformData()
+            {
+                Abbreviation = "GS2",
+                Name = "GlogStation 2",
+            };
+
+            var builder = PrepareTestSiteBuilder(
+                testPlatformData);
+
+            var testText = "There were no good <platform:GS2> games";
+
+            var result = Markdown.Normalize(testText, pipeline: builder.GetMarkdownPipeline());
+
+            Assert.AreEqual(testText, result);
+        }
+
+        [TestMethod]
+        public void TestGlogPlatformAutolinkRoundtrip()
+        {
+            var testPlatformData = new PlatformData()
+            {
+                Abbreviation = "GS2",
+                Name = "GlogStation 2",
+            };
+
+            var builder = PrepareTestSiteBuilder(
+                testPlatformData);
+
+            var testText = "There were no good <platform:GS2> games";
+
+            var mdDoc = Markdown.Parse(testText, builder.GetMarkdownPipeline());
+
+            var result = mdDoc.ToMarkdownString(builder.GetMarkdownPipeline());
+
+            Assert.AreEqual(testText, result);
+        }
+
+        [TestMethod]
+        public void TestGlogPlatformLink()
+        {
+            var testPlatformData = new PlatformData()
+            {
+                Abbreviation = "GS2",
+                Name = "GlogStation 2",
+            };
+
+            var builder = PrepareTestSiteBuilder(
+                testPlatformData);
+
+            var testText = "There were no good [GlogStation 2](platform:GS2) games";
+
+            var result = Markdown.ToHtml(testText, builder.GetMarkdownPipeline());
+
+            Assert.AreEqual("<p>There were no good <a href=\"fake://test.url/platform/gs2\">GlogStation 2</a> games</p>\n", result);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void TestGlogPlatformLinkNotFound()
+        {
+            var builder = PrepareTestSiteBuilder();
+
+            var testText = "There were no good [GlogStation 2](platform:GS2) games";
+
+            Markdown.ToHtml(testText, builder.GetMarkdownPipeline());
+        }
+
+        [TestMethod]
+        public void TestGlogPlatformLinkNormalize()
+        {
+            var testPlatformData = new PlatformData()
+            {
+                Abbreviation = "GS2",
+                Name = "GlogStation 2",
+            };
+
+            var builder = PrepareTestSiteBuilder(
+                testPlatformData);
+
+            var testText = "There were no good [GlogStation 2](platform:GS2) games";
+
+            var result = Markdown.Normalize(testText, pipeline: builder.GetMarkdownPipeline());
+
+            Assert.AreEqual(testText, result);
+        }
+
+        [TestMethod]
+        public void TestGlogPlatformLinkRoundtrip()
+        {
+            var testPlatformData = new PlatformData()
+            {
+                Abbreviation = "GS2",
+                Name = "GlogStation 2",
+            };
+
+            var builder = PrepareTestSiteBuilder(
+                testPlatformData);
+
+            var testText = "There were no good [GlogStation 2](platform:GS2) games";
+
+            var mdDoc = Markdown.Parse(testText, builder.GetMarkdownPipeline());
+
+            var result = mdDoc.ToMarkdownString(builder.GetMarkdownPipeline());
+
+            Assert.AreEqual(testText, result);
+        }
+
+        [TestMethod]
+        public void TestGlogTagAutolink()
+        {
+            var testTagData = new TagData("Gamedev Inc.");
+
+            var builder = PrepareTestSiteBuilder(
+                testTagData);
+
+            var testText = "Waiting for <tag:Gamedev Inc.>'s next game";
+
+            var result = Markdown.ToHtml(testText, builder.GetMarkdownPipeline());
+
+            Assert.AreEqual("<p>Waiting for <a href=\"fake://test.url/tag/gamedev-inc\">Gamedev Inc.</a>'s next game</p>\n", result);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void TestGlogTagAutolinkNotFound()
+        {
+            var builder = PrepareTestSiteBuilder();
+
+            var testText = "Waiting for <tag:Gamedev Inc.>'s next game";
+
+            Markdown.ToHtml(testText, builder.GetMarkdownPipeline());
+        }
+
+        [TestMethod]
+        public void TestGlogTagAutolinkNormalize()
+        {
+            var testTagData = new TagData("Gamedev Inc.");
+
+            var builder = PrepareTestSiteBuilder(
+                testTagData);
+
+            var testText = "Waiting for <tag:Gamedev Inc.>'s next game";
+
+            var result = Markdown.Normalize(testText, pipeline: builder.GetMarkdownPipeline());
+
+            Assert.AreEqual(testText, result);
+        }
+
+        [TestMethod]
+        public void TestGlogTagAutolinkRoundtrip()
+        {
+            var testTagData = new TagData("Gamedev Inc.");
+
+            var builder = PrepareTestSiteBuilder(
+                testTagData);
+
+            var testText = "Waiting for <tag:Gamedev Inc.>'s next game";
+
+            var mdDoc = Markdown.Parse(testText, builder.GetMarkdownPipeline());
+
+            var result = mdDoc.ToMarkdownString(builder.GetMarkdownPipeline());
+
+            Assert.AreEqual(testText, result);
+        }
+
+        [TestMethod]
+        public void TestGlogTagLink()
+        {
+            var testTagData = new TagData("Gamedev Inc.");
+
+            var builder = PrepareTestSiteBuilder(
+                testTagData);
+
+            var testText = "Waiting for [that studio](tag:Gamedev Inc.)'s next game";
+
+            var result = Markdown.ToHtml(testText, builder.GetMarkdownPipeline());
+
+            Assert.AreEqual("<p>Waiting for <a href=\"fake://test.url/tag/gamedev-inc\">that studio</a>'s next game</p>\n", result);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void TestGlogTagLinkNotFound()
+        {
+            var builder = PrepareTestSiteBuilder();
+
+            var testText = "Waiting for [that studio](tag:Gamedev Inc.)'s next game";
+
+            Markdown.ToHtml(testText, builder.GetMarkdownPipeline());
+        }
+
+        [TestMethod]
+        public void TestGlogTagLinkNormalize()
+        {
+            var testTagData = new TagData("Gamedev Inc.");
+
+            var builder = PrepareTestSiteBuilder(
+                testTagData);
+
+            var testText = "Waiting for [that studio](tag:Gamedev Inc.)'s next game";
+
+            var result = Markdown.Normalize(testText, pipeline: builder.GetMarkdownPipeline());
+
+            Assert.AreEqual(testText, result);
+        }
+
+        [TestMethod]
+        public void TestGlogTagLinkRoundtrip()
+        {
+            var testTagData = new TagData("Gamedev Inc.");
+
+            var builder = PrepareTestSiteBuilder(
+                testTagData);
+
+            var testText = "Waiting for [that studio](tag:Gamedev Inc.)'s next game";
+
+            var mdDoc = Markdown.Parse(testText, builder.GetMarkdownPipeline());
+
+            var result = mdDoc.ToMarkdownString(builder.GetMarkdownPipeline());
+
+            Assert.AreEqual(testText, result);
+        }
+    }
+}

--- a/GlogGenerator.Test/MarkdownExtensions/ListTests.cs
+++ b/GlogGenerator.Test/MarkdownExtensions/ListTests.cs
@@ -1,0 +1,100 @@
+using GlogGenerator.MarkdownExtensions;
+using Markdig;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace GlogGenerator.Test.MarkdownExtensions
+{
+    [TestClass]
+    public class ListTests
+    {
+        [TestMethod]
+        public void TestUnorderedList()
+        {
+            var builder = new SiteBuilder();
+
+            var testText = @"* first item
+* second item
+* third item";
+
+            var result = Markdown.ToHtml(testText, builder.GetMarkdownPipeline());
+
+            Assert.AreEqual("<ul>\n<li> first item</li>\n<li> second item</li>\n<li> third item</li>\n</ul>\n", result);
+        }
+
+        [TestMethod]
+        public void TestUnorderedListRoundtrip()
+        {
+            var builder = new SiteBuilder();
+
+            var testText = @"* first item
+* second item
+* third item";
+
+            var mdDoc = Markdown.Parse(testText, builder.GetMarkdownPipeline());
+
+            var result = mdDoc.ToMarkdownString(builder.GetMarkdownPipeline());
+
+            Assert.AreEqual(testText, result);
+        }
+
+        [TestMethod]
+        public void TestOrderedListDigits()
+        {
+            var builder = new SiteBuilder();
+
+            var testText = @"1. first item
+2. second item
+3. third item";
+
+            var result = Markdown.ToHtml(testText, builder.GetMarkdownPipeline());
+
+            Assert.AreEqual("<ol>\n<li> first item</li>\n<li> second item</li>\n<li> third item</li>\n</ol>\n", result);
+        }
+
+        [TestMethod]
+        public void TestOrderedListDigitsRoundtrip()
+        {
+            var builder = new SiteBuilder();
+
+            var testText = @"1. first item
+2. second item
+3. third item";
+
+            var mdDoc = Markdown.Parse(testText, builder.GetMarkdownPipeline());
+
+            var result = mdDoc.ToMarkdownString(builder.GetMarkdownPipeline());
+
+            Assert.AreEqual(testText, result);
+        }
+
+        [TestMethod]
+        public void TestOrderedListLetters()
+        {
+            var builder = new SiteBuilder();
+
+            var testText = @"A. first item
+B. second item
+C. third item";
+
+            var result = Markdown.ToHtml(testText, builder.GetMarkdownPipeline());
+
+            Assert.AreEqual("<ol type=\"A\">\n<li> first item</li>\n<li> second item</li>\n<li> third item</li>\n</ol>\n", result);
+        }
+
+        [TestMethod]
+        public void TestOrderedListLettersRoundtrip()
+        {
+            var builder = new SiteBuilder();
+
+            var testText = @"A. first item
+B. second item
+C. third item";
+
+            var mdDoc = Markdown.Parse(testText, builder.GetMarkdownPipeline());
+
+            var result = mdDoc.ToMarkdownString(builder.GetMarkdownPipeline());
+
+            Assert.AreEqual(testText, result);
+        }
+    }
+}

--- a/GlogGenerator.Test/MarkdownExtensions/PipeTableTests.cs
+++ b/GlogGenerator.Test/MarkdownExtensions/PipeTableTests.cs
@@ -1,0 +1,42 @@
+using GlogGenerator.MarkdownExtensions;
+using Markdig;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace GlogGenerator.Test.MarkdownExtensions
+{
+    [TestClass]
+    public class PipeTableTests
+    {
+        [TestMethod]
+        public void TestTableOneRow()
+        {
+            var builder = new SiteBuilder();
+
+            var testText = @"| ![](img1.png){width=200 height=127} | ![](img2.png){width=586 height=251} |
+| - | - |";
+
+            var mdDoc = Markdown.Parse(testText, builder.GetMarkdownPipeline());
+
+            var result = mdDoc.ToMarkdownString(builder.GetMarkdownPipeline());
+
+            Assert.AreEqual(testText, result);
+        }
+
+        [TestMethod]
+        public void TestTableManyRows()
+        {
+            var builder = new SiteBuilder();
+
+            var testText = @"| ![](img1.jpg){width=200 height=150} | ![](img2.jpg){width=200 height=150} | ![](img3.jpg){width=200 height=150} |
+| - | - | - |
+| ![](img4.jpg){width=200 height=150} | ![](img5.jpg){width=200 height=150} | ![](img6.jpg){width=200 height=150} |
+| ![](img7.jpg){width=200 height=150} | ![](img8.jpg){width=200 height=150} | ![](img9.jpg){width=200 height=150} |";
+
+            var mdDoc = Markdown.Parse(testText, builder.GetMarkdownPipeline());
+
+            var result = mdDoc.ToMarkdownString(builder.GetMarkdownPipeline());
+
+            Assert.AreEqual(testText, result);
+        }
+    }
+}

--- a/GlogGenerator.Test/MarkdownExtensions/PipeTableTests.cs
+++ b/GlogGenerator.Test/MarkdownExtensions/PipeTableTests.cs
@@ -8,7 +8,7 @@ namespace GlogGenerator.Test.MarkdownExtensions
     public class PipeTableTests
     {
         [TestMethod]
-        public void TestTableOneRow()
+        public void TestTableOneRowRoundtrip()
         {
             var builder = new SiteBuilder();
 
@@ -23,7 +23,7 @@ namespace GlogGenerator.Test.MarkdownExtensions
         }
 
         [TestMethod]
-        public void TestTableManyRows()
+        public void TestTableManyRowsRoundtrip()
         {
             var builder = new SiteBuilder();
 

--- a/GlogGenerator.Test/MarkdownExtensions/SpoilerTests.cs
+++ b/GlogGenerator.Test/MarkdownExtensions/SpoilerTests.cs
@@ -2,7 +2,6 @@ using System.IO;
 using System.Text;
 using GlogGenerator.MarkdownExtensions;
 using Markdig;
-using Markdig.Renderers.Normalize;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace GlogGenerator.Test.MarkdownExtensions
@@ -58,9 +57,20 @@ namespace GlogGenerator.Test.MarkdownExtensions
             Assert.AreEqual("<p>Incoming spoiler: <noscript><i>JavaScript is disabled, and this concealed spoiler may not appear as expected.</i></noscript><spoiler class=\"spoiler_hidden\" onClick=\"spoiler_toggle(this);\">ohno <noscript><i>JavaScript is disabled, and this concealed spoiler may not appear as expected.</i></noscript><spoiler class=\"spoiler_hidden\" onClick=\"spoiler_toggle(this);\">spoiler within a</spoiler> spoiler</spoiler></p>\n", result);
         }
 
-        [Ignore]
         [TestMethod]
-        public void TestSpoilerNormalized()
+        public void TestSpoilerNormalize()
+        {
+            var builder = new SiteBuilder();
+
+            var testText = "Incoming spoiler: >!ohno spoiler!<";
+
+            var result = Markdown.Normalize(testText, pipeline: builder.GetMarkdownPipeline());
+
+            Assert.AreEqual(testText, result);
+        }
+
+        [TestMethod]
+        public void TestSpoilerRoundtrip()
         {
             var builder = new SiteBuilder();
 
@@ -68,16 +78,9 @@ namespace GlogGenerator.Test.MarkdownExtensions
 
             var mdDoc = Markdown.Parse(testText, builder.GetMarkdownPipeline());
 
-            string normalized;
-            using (var mdTextWriter = new StringWriter())
-            {
-                var mdRenderer = new NormalizeRenderer(mdTextWriter);
-                mdRenderer.Render(mdDoc);
+            var result = mdDoc.ToMarkdownString(builder.GetMarkdownPipeline());
 
-                normalized = mdTextWriter.ToString();
-            }
-
-            Assert.AreEqual(testText, normalized);
+            Assert.AreEqual(testText, result);
         }
     }
 }

--- a/GlogGenerator.Test/MarkdownExtensions/VariableSubstitutionTests.cs
+++ b/GlogGenerator.Test/MarkdownExtensions/VariableSubstitutionTests.cs
@@ -2,7 +2,6 @@ using System.IO;
 using System.Text;
 using GlogGenerator.MarkdownExtensions;
 using Markdig;
-using Markdig.Renderers.Normalize;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace GlogGenerator.Test.MarkdownExtensions
@@ -50,7 +49,20 @@ namespace GlogGenerator.Test.MarkdownExtensions
         }
 
         [TestMethod]
-        public void TestInlineSubstitutionNormalized()
+        public void TestInlineSubstitutionNormalize()
+        {
+            var builder = new SiteBuilder();
+            builder.GetVariableSubstitution().SetSubstitution("TestVar", "replacement text");
+
+            var testText = "Test of $TestVar$ substitution";
+
+            var result = Markdown.Normalize(testText, pipeline: builder.GetMarkdownPipeline());
+
+            Assert.AreEqual(testText, result);
+        }
+
+        [TestMethod]
+        public void TestInlineSubstitutionRoundtrip()
         {
             var builder = new SiteBuilder();
             builder.GetVariableSubstitution().SetSubstitution("TestVar", "replacement text");
@@ -59,16 +71,9 @@ namespace GlogGenerator.Test.MarkdownExtensions
 
             var mdDoc = Markdown.Parse(testText, builder.GetMarkdownPipeline());
 
-            string normalized;
-            using (var mdTextWriter = new StringWriter())
-            {
-                var mdRenderer = new NormalizeRenderer(mdTextWriter);
-                mdRenderer.Render(mdDoc);
+            var result = mdDoc.ToMarkdownString(builder.GetMarkdownPipeline());
 
-                normalized = mdTextWriter.ToString();
-            }
-
-            Assert.AreEqual(testText, normalized);
+            Assert.AreEqual(testText, result);
         }
 
         [TestMethod]
@@ -85,7 +90,20 @@ namespace GlogGenerator.Test.MarkdownExtensions
         }
 
         [TestMethod]
-        public void TestAutolinkInlineSubstitutionNormalized()
+        public void TestAutolinkInlineSubstitutionNormalize()
+        {
+            var builder = new SiteBuilder();
+            builder.GetVariableSubstitution().SetSubstitution("TestVar", "replacement.text");
+
+            var testText = "Test of <https://$TestVar$> substitution";
+
+            var result = Markdown.Normalize(testText, pipeline: builder.GetMarkdownPipeline());
+
+            Assert.AreEqual(testText, result);
+        }
+
+        [TestMethod]
+        public void TestAutolinkInlineSubstitutionRoundtrip()
         {
             var builder = new SiteBuilder();
             builder.GetVariableSubstitution().SetSubstitution("TestVar", "replacement.text");
@@ -94,16 +112,9 @@ namespace GlogGenerator.Test.MarkdownExtensions
 
             var mdDoc = Markdown.Parse(testText, builder.GetMarkdownPipeline());
 
-            string normalized;
-            using (var mdTextWriter = new StringWriter())
-            {
-                var mdRenderer = new NormalizeRenderer(mdTextWriter);
-                mdRenderer.Render(mdDoc);
+            var result = mdDoc.ToMarkdownString(builder.GetMarkdownPipeline());
 
-                normalized = mdTextWriter.ToString();
-            }
-
-            Assert.AreEqual(testText, normalized);
+            Assert.AreEqual(testText, result);
         }
 
         [TestMethod]
@@ -120,7 +131,20 @@ namespace GlogGenerator.Test.MarkdownExtensions
         }
 
         [TestMethod]
-        public void TestLinkInlineSubstitutionNormalized()
+        public void TestLinkInlineSubstitutionNormalize()
+        {
+            var builder = new SiteBuilder();
+            builder.GetVariableSubstitution().SetSubstitution("TestVar", "replacement.text");
+
+            var testText = "Test of [link text](https://$TestVar$) substitution";
+
+            var result = Markdown.Normalize(testText, pipeline: builder.GetMarkdownPipeline());
+
+            Assert.AreEqual(testText, result);
+        }
+
+        [TestMethod]
+        public void TestLinkInlineSubstitutionRoundtrip()
         {
             var builder = new SiteBuilder();
             builder.GetVariableSubstitution().SetSubstitution("TestVar", "replacement.text");
@@ -129,16 +153,9 @@ namespace GlogGenerator.Test.MarkdownExtensions
 
             var mdDoc = Markdown.Parse(testText, builder.GetMarkdownPipeline());
 
-            string normalized;
-            using (var mdTextWriter = new StringWriter())
-            {
-                var mdRenderer = new NormalizeRenderer(mdTextWriter);
-                mdRenderer.Render(mdDoc);
+            var result = mdDoc.ToMarkdownString(builder.GetMarkdownPipeline());
 
-                normalized = mdTextWriter.ToString();
-            }
-
-            Assert.AreEqual(testText, normalized);
+            Assert.AreEqual(testText, result);
         }
 
         [TestMethod]
@@ -156,7 +173,21 @@ namespace GlogGenerator.Test.MarkdownExtensions
 
         [Ignore]
         [TestMethod]
-        public void TestMediaLinkSubstitutionNormalized()
+        public void TestMediaLinkSubstitutionNormalize()
+        {
+            var builder = new SiteBuilder();
+            builder.GetVariableSubstitution().SetSubstitution("TestVar", "replacement.text");
+
+            var testText = "Test of ![static mp4](https://$TestVar$/video.mp4){width=960 height=540 controls} substitution";
+
+            var result = Markdown.Normalize(testText, pipeline: builder.GetMarkdownPipeline());
+
+            Assert.AreEqual(testText, result);
+        }
+
+        [Ignore]
+        [TestMethod]
+        public void TestMediaLinkSubstitutionRoundtrip()
         {
             var builder = new SiteBuilder();
             builder.GetVariableSubstitution().SetSubstitution("TestVar", "replacement.text");
@@ -165,16 +196,9 @@ namespace GlogGenerator.Test.MarkdownExtensions
 
             var mdDoc = Markdown.Parse(testText, builder.GetMarkdownPipeline());
 
-            string normalized;
-            using (var mdTextWriter = new StringWriter())
-            {
-                var mdRenderer = new NormalizeRenderer(mdTextWriter);
-                mdRenderer.Render(mdDoc);
+            var result = mdDoc.ToMarkdownString(builder.GetMarkdownPipeline());
 
-                normalized = mdTextWriter.ToString();
-            }
-
-            Assert.AreEqual(testText, normalized);
+            Assert.AreEqual(testText, result);
         }
     }
 }

--- a/GlogGenerator.Test/MarkdownExtensions/VariableSubstitutionTests.cs
+++ b/GlogGenerator.Test/MarkdownExtensions/VariableSubstitutionTests.cs
@@ -171,7 +171,6 @@ namespace GlogGenerator.Test.MarkdownExtensions
             Assert.AreEqual("<p>Test of <video width=\"960\" height=\"540\" controls=\"\"><source type=\"video/mp4\" src=\"https://replacement.text/video.mp4\"></source></video> substitution</p>\n", result);
         }
 
-        [Ignore]
         [TestMethod]
         public void TestMediaLinkSubstitutionNormalize()
         {
@@ -185,7 +184,6 @@ namespace GlogGenerator.Test.MarkdownExtensions
             Assert.AreEqual(testText, result);
         }
 
-        [Ignore]
         [TestMethod]
         public void TestMediaLinkSubstitutionRoundtrip()
         {

--- a/GlogGenerator/Data/GameData.cs
+++ b/GlogGenerator/Data/GameData.cs
@@ -27,12 +27,17 @@ namespace GlogGenerator.Data
 
         public string GetReferenceableKey()
         {
-            return this.referenceableKey;
+            if (!string.IsNullOrEmpty(this.referenceableKey))
+            {
+                return this.referenceableKey;
+            }
+
+            return UrlizedString.Urlize(this.Title);
         }
 
         public string GetPermalinkRelative()
         {
-            return $"game/{this.referenceableKey}/";
+            return $"game/{this.GetReferenceableKey()}/";
         }
 
         public static GameData FromIgdbGame(IIgdbCache igdbCache, IgdbGame igdbGame)

--- a/GlogGenerator/Data/ISiteDataIndex.cs
+++ b/GlogGenerator/Data/ISiteDataIndex.cs
@@ -29,5 +29,7 @@ namespace GlogGenerator.Data
         public List<TagData> GetTags();
 
         public void LoadContent(IIgdbCache igdbCache);
+
+        public void RewriteSourceContent();
     }
 }

--- a/GlogGenerator/Data/ISiteDataIndex.cs
+++ b/GlogGenerator/Data/ISiteDataIndex.cs
@@ -1,0 +1,33 @@
+﻿using System.Collections.Generic;
+
+namespace GlogGenerator.Data
+{
+    public interface ISiteDataIndex
+    {
+        public List<CategoryData> GetCategories();
+
+        public GameData GetGame(string gameTitle);
+
+        public List<GameData> GetGames();
+
+        public List<PageData> GetPages();
+
+        public PlatformData GetPlatform(string platformAbbreviation);
+
+        public List<PlatformData> GetPlatforms();
+
+        public List<PostData> GetPosts();
+
+        public List<RatingData> GetRatings();
+
+        public string GetRawDataFile(string filePath);
+
+        public List<StaticFileData> GetStaticFiles();
+
+        public TagData GetTag(string tagName);
+
+        public List<TagData> GetTags();
+
+        public void LoadContent(IIgdbCache igdbCache);
+    }
+}

--- a/GlogGenerator/Data/PageData.cs
+++ b/GlogGenerator/Data/PageData.cs
@@ -1,4 +1,6 @@
+using System.IO;
 using System.Runtime.Serialization;
+using System.Text;
 using GlogGenerator.MarkdownExtensions;
 using Markdig;
 
@@ -13,6 +15,19 @@ namespace GlogGenerator.Data
 
         [DataMember(Name = "permalink")]
         public string PermalinkRelative { get; private set; } = string.Empty;
+
+        public void RewriteSourceFile(MarkdownPipeline mdPipeline)
+        {
+            if (string.IsNullOrEmpty(SourceFilePath))
+            {
+                throw new InvalidDataException("SourceFilePath is empty");
+            }
+
+            var fileContent = this.ToMarkdownString(mdPipeline);
+
+            var utf8WithoutBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+            File.WriteAllText(this.SourceFilePath, fileContent, utf8WithoutBom);
+        }
 
         public static PageData MarkdownFromFilePath(MarkdownPipeline mdPipeline, string filePath)
         {

--- a/GlogGenerator/Data/PlatformData.cs
+++ b/GlogGenerator/Data/PlatformData.cs
@@ -24,12 +24,17 @@ namespace GlogGenerator.Data
 
         public string GetReferenceableKey()
         {
-            return this.referenceableKey;
+            if (!string.IsNullOrEmpty(this.referenceableKey))
+            {
+                return this.referenceableKey;
+            }
+
+            return UrlizedString.Urlize(this.Abbreviation);
         }
 
         public string GetPermalinkRelative()
         {
-            return $"platform/{this.referenceableKey}/";
+            return $"platform/{this.GetReferenceableKey()}/";
         }
 
         public static PlatformData FromIgdbPlatform(IIgdbCache igdbCache, IgdbPlatform igdbPlatform)

--- a/GlogGenerator/Data/PostData.cs
+++ b/GlogGenerator/Data/PostData.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Runtime.Serialization;
+using System.Text;
 using GlogGenerator.MarkdownExtensions;
 using Markdig;
 
@@ -48,6 +50,19 @@ namespace GlogGenerator.Data
 
         [DataMember(Name = "slug")]
         public string Slug { get; private set; } = null;
+
+        public void RewriteSourceFile(MarkdownPipeline mdPipeline)
+        {
+            if (string.IsNullOrEmpty(SourceFilePath))
+            {
+                throw new InvalidDataException("SourceFilePath is empty");
+            }
+
+            var fileContent = this.ToMarkdownString(mdPipeline);
+
+            var utf8WithoutBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+            File.WriteAllText(this.SourceFilePath, fileContent, utf8WithoutBom);
+        }
 
         public static PostData MarkdownFromFilePath(MarkdownPipeline mdPipeline, string filePath)
         {

--- a/GlogGenerator/Data/PostData.cs
+++ b/GlogGenerator/Data/PostData.cs
@@ -17,9 +17,6 @@ namespace GlogGenerator.Data
         [IgnoreDataMember]
         public string PermalinkRelative { get; private set; } = string.Empty;
 
-        [DataMember(Name = "draft")]
-        public bool Draft { get; private set; } = false;
-
         // Parsing hack alert!
         // Tomlyn's ToModel conversion uses Convert.ChangeType() which requires
         // the target type to implement IConvertible; but DateTimeOffset doesn't.
@@ -31,6 +28,9 @@ namespace GlogGenerator.Data
         [IgnoreDataMember]
         public DateTimeOffset Date { get; private set; } = DateTimeOffset.MinValue;
 
+        [DataMember(Name = "draft")]
+        public bool? Draft { get; private set; } = null;
+
         [DataMember(Name = "title")]
         public string Title { get; private set; } = string.Empty;
 
@@ -38,16 +38,16 @@ namespace GlogGenerator.Data
         public List<string> Categories { get; private set; } = new List<string>();
 
         [DataMember(Name = "game")]
-        public List<string> Games { get; private set; } = new List<string>();
+        public List<string> Games { get; private set; } = null;
 
         [DataMember(Name = "platform")]
-        public List<string> Platforms { get; private set; } = new List<string>();
+        public List<string> Platforms { get; private set; } = null;
 
         [DataMember(Name = "rating")]
-        public List<string> Ratings { get; private set; } = new List<string>();
+        public List<string> Ratings { get; private set; } = null;
 
         [DataMember(Name = "slug")]
-        public string Slug { get; private set; } = string.Empty;
+        public string Slug { get; private set; } = null;
 
         public static PostData MarkdownFromFilePath(MarkdownPipeline mdPipeline, string filePath)
         {

--- a/GlogGenerator/Data/SiteDataIndex.cs
+++ b/GlogGenerator/Data/SiteDataIndex.cs
@@ -355,6 +355,19 @@ namespace GlogGenerator.Data
             this.CheckUpdatedReferenceableDataForConflict(oldTags, this.tags);
         }
 
+        public void RewriteSourceContent()
+        {
+            foreach (var page in this.pages)
+            {
+                page.RewriteSourceFile(this.siteBuilder.GetMarkdownPipeline());
+            }
+
+            foreach (var post in this.posts)
+            {
+                post.RewriteSourceFile(this.siteBuilder.GetMarkdownPipeline());
+            }
+        }
+
         private void CheckUpdatedReferenceableDataForConflict<T>(Dictionary<UrlizedString, T> oldData, Dictionary<UrlizedString, T> newData)
             where T : IGlogReferenceable
         {

--- a/GlogGenerator/Data/SiteDataIndex.cs
+++ b/GlogGenerator/Data/SiteDataIndex.cs
@@ -276,7 +276,7 @@ namespace GlogGenerator.Data
                     {
                         var postData = PostData.MarkdownFromFilePath(mdPipeline, postPath);
 
-                        if (postData.Draft)
+                        if (postData.Draft == true)
                         {
                             continue;
                         }
@@ -290,15 +290,18 @@ namespace GlogGenerator.Data
                         }
 
                         var postGameTags = new Dictionary<UrlizedString, TagData>();
-                        foreach (var game in postData.Games)
+                        if (postData.Games != null)
                         {
-                            var gameData = this.GetGame(game);
-                            gameData.LinkedPosts.Add(postData);
-
-                            foreach (var tag in gameData.Tags)
+                            foreach (var game in postData.Games)
                             {
-                                var tagNameUrlized = new UrlizedString(tag);
-                                postGameTags[tagNameUrlized] = this.GetTag(tag);
+                                var gameData = this.GetGame(game);
+                                gameData.LinkedPosts.Add(postData);
+
+                                foreach (var tag in gameData.Tags)
+                                {
+                                    var tagNameUrlized = new UrlizedString(tag);
+                                    postGameTags[tagNameUrlized] = this.GetTag(tag);
+                                }
                             }
                         }
 
@@ -307,16 +310,22 @@ namespace GlogGenerator.Data
                             tagData.LinkedPosts.Add(postData);
                         }
 
-                        foreach (var platform in postData.Platforms)
+                        if (postData.Platforms != null)
                         {
-                            var platformData = this.GetPlatform(platform);
-                            platformData.LinkedPosts.Add(postData);
+                            foreach (var platform in postData.Platforms)
+                            {
+                                var platformData = this.GetPlatform(platform);
+                                platformData.LinkedPosts.Add(postData);
+                            }
                         }
 
-                        foreach (var rating in postData.Ratings)
+                        if (postData.Ratings != null)
                         {
-                            var ratingData = this.AddRatingIfMissing(rating);
-                            ratingData.LinkedPosts.Add(postData);
+                            foreach (var rating in postData.Ratings)
+                            {
+                                var ratingData = this.AddRatingIfMissing(rating);
+                                ratingData.LinkedPosts.Add(postData);
+                            }
                         }
                     }
                     catch (Exception ex)

--- a/GlogGenerator/Data/SiteDataIndex.cs
+++ b/GlogGenerator/Data/SiteDataIndex.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Logging;
 
 namespace GlogGenerator.Data
 {
-    public class SiteDataIndex
+    public class SiteDataIndex: ISiteDataIndex
     {
         private readonly ILogger logger;
         private readonly ISiteBuilder siteBuilder;
@@ -34,7 +34,7 @@ namespace GlogGenerator.Data
             this.inputFilesBasePath = inputFilesBasePath;
         }
 
-        public CategoryData AddCategoryIfMissing(string categoryName)
+        private CategoryData AddCategoryIfMissing(string categoryName)
         {
             var categoryNameUrlized = new UrlizedString(categoryName);
             if (!this.categories.TryGetValue(categoryNameUrlized, out var categoryData))
@@ -50,7 +50,7 @@ namespace GlogGenerator.Data
             return categoryData;
         }
 
-        public RatingData AddRatingIfMissing(string ratingName)
+        private RatingData AddRatingIfMissing(string ratingName)
         {
             var ratingNameUrlized = new UrlizedString(ratingName);
             if (!this.ratings.TryGetValue(ratingNameUrlized, out var ratingData))
@@ -147,39 +147,6 @@ namespace GlogGenerator.Data
         public List<TagData> GetTags()
         {
             return this.tags.Values.ToList();
-        }
-
-        public GameData ValidateMatchingGameName(string gameName)
-        {
-            var gameNameUrlized = new UrlizedString(gameName);
-            if (!this.games.TryGetValue(gameNameUrlized, out var gameData))
-            {
-                throw new ArgumentException($"Game name \"{gameName}\" doesn't appear to exist in site data");
-            }
-
-            return gameData;
-        }
-
-        public PlatformData ValidateMatchingPlatformAbbreviation(string platformAbbreviation)
-        {
-            var platformAbbreviationUrlized = new UrlizedString(platformAbbreviation);
-            if (!this.platforms.TryGetValue(platformAbbreviationUrlized, out var platformData))
-            {
-                throw new ArgumentException($"Platform abbreviation \"{platformAbbreviation}\" doesn't appear to exist in site data");
-            }
-
-            return platformData;
-        }
-
-        public TagData ValidateMatchingTagName(string tagName)
-        {
-            var tagNameUrlized = new UrlizedString(tagName);
-            if (!this.tags.TryGetValue(tagNameUrlized, out var tagData))
-            {
-                throw new ArgumentException($"Tag name \"{tagName}\" doesn't appear to exist in site data");
-            }
-
-            return tagData;
         }
 
         private static void CreateOrMergeMultiKeyReferenceableData<T>(Dictionary<UrlizedString, T> index, string dataKey)

--- a/GlogGenerator/MarkdownExtensions/ContentWithFrontMatterData.cs
+++ b/GlogGenerator/MarkdownExtensions/ContentWithFrontMatterData.cs
@@ -14,7 +14,7 @@ namespace GlogGenerator.MarkdownExtensions
     public class ContentWithFrontMatterData
     {
         [IgnoreDataMember]
-        public MarkdownDocument Content { get; private set; }
+        public MarkdownDocument MdDoc { get; private set; }
 
         public static T FromFilePath<T>(MarkdownPipeline mdPipeline, string filePath)
             where T : ContentWithFrontMatterData, new()
@@ -29,41 +29,20 @@ namespace GlogGenerator.MarkdownExtensions
             {
                 var tomlString = tomlBlock.Content;
                 contentAndData = Tomlyn.Toml.ToModel<T>(tomlString);
-
-                mdDoc.Remove(tomlBlock);
             }
             else
             {
                 contentAndData = new T();
             }
 
-            contentAndData.Content = mdDoc;
+            contentAndData.MdDoc = mdDoc;
 
             return contentAndData;
         }
 
         public string ToMarkdownString(MarkdownPipeline mdPipeline)
         {
-            var stringBuilder = new StringBuilder();
-
-            var tomlOutOptions = new Tomlyn.TomlModelOptions()
-            {
-                IgnoreMissingProperties = true,
-            };
-            var frontMatterText = Tomlyn.Toml.FromModel(this, tomlOutOptions);
-
-            if (!string.IsNullOrEmpty(frontMatterText))
-            {
-                frontMatterText = frontMatterText.ReplaceLineEndings("\n");
-
-                stringBuilder.Append("+++\n");
-                stringBuilder.Append(frontMatterText);
-                stringBuilder.Append("+++\n");
-            }
-
-            stringBuilder.Append(this.Content.ToMarkdownString(mdPipeline));
-
-            return stringBuilder.ToString();
+            return this.MdDoc.ToMarkdownString(mdPipeline);
         }
     }
 }

--- a/GlogGenerator/MarkdownExtensions/ContentWithFrontMatterData.cs
+++ b/GlogGenerator/MarkdownExtensions/ContentWithFrontMatterData.cs
@@ -54,9 +54,11 @@ namespace GlogGenerator.MarkdownExtensions
 
             if (!string.IsNullOrEmpty(frontMatterText))
             {
-                stringBuilder.AppendLine("+++");
+                frontMatterText = frontMatterText.ReplaceLineEndings("\n");
+
+                stringBuilder.Append("+++\n");
                 stringBuilder.Append(frontMatterText);
-                stringBuilder.AppendLine("+++");
+                stringBuilder.Append("+++\n");
             }
 
             stringBuilder.Append(this.Content.ToMarkdownString(mdPipeline));

--- a/GlogGenerator/MarkdownExtensions/ContentWithFrontMatterData.cs
+++ b/GlogGenerator/MarkdownExtensions/ContentWithFrontMatterData.cs
@@ -61,9 +61,6 @@ namespace GlogGenerator.MarkdownExtensions
 
             stringBuilder.Append(this.Content.ToMarkdownString(mdPipeline));
 
-            // Always end the file with a line break.
-            stringBuilder.AppendLine();
-
             return stringBuilder.ToString();
         }
     }

--- a/GlogGenerator/MarkdownExtensions/ContentWithFrontMatterData.cs
+++ b/GlogGenerator/MarkdownExtensions/ContentWithFrontMatterData.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Runtime.Serialization;
 using System.Text;
 using Markdig;
-using Markdig.Renderers.Normalize;
 using Markdig.Syntax;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -43,7 +42,7 @@ namespace GlogGenerator.MarkdownExtensions
             return contentAndData;
         }
 
-        public override string ToString()
+        public string ToMarkdownString(MarkdownPipeline mdPipeline)
         {
             var stringBuilder = new StringBuilder();
 
@@ -60,13 +59,7 @@ namespace GlogGenerator.MarkdownExtensions
                 stringBuilder.AppendLine("+++");
             }
 
-            using (var mdTextWriter = new StringWriter())
-            {
-                var mdRenderer = new NormalizeRenderer(mdTextWriter);
-                mdRenderer.Render(this.Content);
-
-                stringBuilder.Append(mdTextWriter.ToString());
-            }
+            stringBuilder.Append(this.Content.ToMarkdownString(mdPipeline));
 
             // Always end the file with a line break.
             stringBuilder.AppendLine();

--- a/GlogGenerator/MarkdownExtensions/FencedDataBlockHtmlRenderer.cs
+++ b/GlogGenerator/MarkdownExtensions/FencedDataBlockHtmlRenderer.cs
@@ -16,12 +16,12 @@ using Newtonsoft.Json.Linq;
 
 namespace GlogGenerator.MarkdownExtensions
 {
-    public class FencedDataBlockRenderer : HtmlObjectRenderer<FencedDataBlock>
+    public class FencedDataBlockHtmlRenderer : HtmlObjectRenderer<FencedDataBlock>
     {
         private readonly ISiteDataIndex siteDataIndex;
         private readonly HtmlRendererContext htmlRendererContext;
 
-        public FencedDataBlockRenderer(
+        public FencedDataBlockHtmlRenderer(
             ISiteDataIndex siteDataIndex,
             HtmlRendererContext htmlRendererContext)
         {

--- a/GlogGenerator/MarkdownExtensions/FencedDataBlockNormalizeRenderer.cs
+++ b/GlogGenerator/MarkdownExtensions/FencedDataBlockNormalizeRenderer.cs
@@ -6,6 +6,8 @@ namespace GlogGenerator.MarkdownExtensions
     {
         protected override void Write(NormalizeRenderer renderer, FencedDataBlock obj)
         {
+            renderer.Write(obj.TriviaBefore);
+
             renderer.Write(":::");
             renderer.WriteLine(obj.Info);
             foreach (var kv in obj.Data)
@@ -16,6 +18,8 @@ namespace GlogGenerator.MarkdownExtensions
                 renderer.WriteLine();
             }
             renderer.Write(":::");
+
+            renderer.Write(obj.TriviaAfter);
         }
     }
 }

--- a/GlogGenerator/MarkdownExtensions/FencedDataBlockNormalizeRenderer.cs
+++ b/GlogGenerator/MarkdownExtensions/FencedDataBlockNormalizeRenderer.cs
@@ -1,4 +1,5 @@
-﻿using Markdig.Renderers.Normalize;
+﻿using Markdig.Helpers;
+using Markdig.Renderers.Normalize;
 
 namespace GlogGenerator.MarkdownExtensions
 {
@@ -20,6 +21,11 @@ namespace GlogGenerator.MarkdownExtensions
             renderer.Write(":::");
 
             renderer.Write(obj.TriviaAfter);
+
+            if (obj.NewLine != NewLine.None)
+            {
+                renderer.Write(obj.NewLine.AsString());
+            }
         }
     }
 }

--- a/GlogGenerator/MarkdownExtensions/FencedDataBlockNormalizeRenderer.cs
+++ b/GlogGenerator/MarkdownExtensions/FencedDataBlockNormalizeRenderer.cs
@@ -1,0 +1,21 @@
+﻿using Markdig.Renderers.Normalize;
+
+namespace GlogGenerator.MarkdownExtensions
+{
+    public class FencedDataBlockNormalizeRenderer : NormalizeObjectRenderer<FencedDataBlock>
+    {
+        protected override void Write(NormalizeRenderer renderer, FencedDataBlock obj)
+        {
+            renderer.Write(":::");
+            renderer.WriteLine(obj.Info);
+            foreach (var kv in obj.Data)
+            {
+                renderer.Write(kv.Key);
+                renderer.Write(": ");
+                renderer.Write(kv.Value.ToString());
+                renderer.WriteLine();
+            }
+            renderer.Write(":::");
+        }
+    }
+}

--- a/GlogGenerator/MarkdownExtensions/FencedDataBlockParser.cs
+++ b/GlogGenerator/MarkdownExtensions/FencedDataBlockParser.cs
@@ -14,7 +14,17 @@ namespace GlogGenerator.MarkdownExtensions
 
         protected override FencedDataBlock CreateFencedBlock(BlockProcessor processor)
         {
-            return new FencedDataBlock(this);
+            var dataBlock = new FencedDataBlock(this);
+
+            if (processor.TrackTrivia)
+            {
+                dataBlock.LinesBefore = processor.LinesBefore;
+                processor.LinesBefore = null;
+                dataBlock.TriviaBefore = processor.UseTrivia(processor.Start - 1);
+                dataBlock.NewLine = processor.Line.NewLine;
+            }
+
+            return dataBlock;
         }
 
         public override BlockState TryContinue(BlockProcessor processor, Block block)

--- a/GlogGenerator/MarkdownExtensions/FencedDataBlockRenderer.cs
+++ b/GlogGenerator/MarkdownExtensions/FencedDataBlockRenderer.cs
@@ -18,11 +18,11 @@ namespace GlogGenerator.MarkdownExtensions
 {
     public class FencedDataBlockRenderer : HtmlObjectRenderer<FencedDataBlock>
     {
-        private readonly SiteDataIndex siteDataIndex;
+        private readonly ISiteDataIndex siteDataIndex;
         private readonly HtmlRendererContext htmlRendererContext;
 
         public FencedDataBlockRenderer(
-            SiteDataIndex siteDataIndex,
+            ISiteDataIndex siteDataIndex,
             HtmlRendererContext htmlRendererContext)
         {
             this.siteDataIndex = siteDataIndex;

--- a/GlogGenerator/MarkdownExtensions/FencedDataBlockRoundtripRenderer.cs
+++ b/GlogGenerator/MarkdownExtensions/FencedDataBlockRoundtripRenderer.cs
@@ -1,0 +1,21 @@
+﻿using Markdig.Renderers.Roundtrip;
+
+namespace GlogGenerator.MarkdownExtensions
+{
+    public class FencedDataBlockRoundtripeRenderer : RoundtripObjectRenderer<FencedDataBlock>
+    {
+        protected override void Write(RoundtripRenderer renderer, FencedDataBlock obj)
+        {
+            renderer.Write(":::");
+            renderer.WriteLine(obj.Info);
+            foreach (var kv in obj.Data)
+            {
+                renderer.Write(kv.Key);
+                renderer.Write(": ");
+                renderer.Write(kv.Value.ToString());
+                renderer.WriteLine();
+            }
+            renderer.Write(":::");
+        }
+    }
+}

--- a/GlogGenerator/MarkdownExtensions/FencedDataBlockRoundtripRenderer.cs
+++ b/GlogGenerator/MarkdownExtensions/FencedDataBlockRoundtripRenderer.cs
@@ -6,6 +6,8 @@ namespace GlogGenerator.MarkdownExtensions
     {
         protected override void Write(RoundtripRenderer renderer, FencedDataBlock obj)
         {
+            renderer.Write(obj.TriviaBefore);
+
             renderer.Write(":::");
             renderer.WriteLine(obj.Info);
             foreach (var kv in obj.Data)
@@ -16,6 +18,8 @@ namespace GlogGenerator.MarkdownExtensions
                 renderer.WriteLine();
             }
             renderer.Write(":::");
+
+            renderer.Write(obj.TriviaAfter);
         }
     }
 }

--- a/GlogGenerator/MarkdownExtensions/FencedDataBlockRoundtripRenderer.cs
+++ b/GlogGenerator/MarkdownExtensions/FencedDataBlockRoundtripRenderer.cs
@@ -1,4 +1,5 @@
-﻿using Markdig.Renderers.Roundtrip;
+﻿using Markdig.Helpers;
+using Markdig.Renderers.Roundtrip;
 
 namespace GlogGenerator.MarkdownExtensions
 {
@@ -6,6 +7,8 @@ namespace GlogGenerator.MarkdownExtensions
     {
         protected override void Write(RoundtripRenderer renderer, FencedDataBlock obj)
         {
+            renderer.RenderLinesBefore(obj);
+
             renderer.Write(obj.TriviaBefore);
 
             renderer.Write(":::");
@@ -20,6 +23,13 @@ namespace GlogGenerator.MarkdownExtensions
             renderer.Write(":::");
 
             renderer.Write(obj.TriviaAfter);
+
+            if (obj.NewLine != NewLine.None)
+            {
+                renderer.Write(obj.NewLine.AsString());
+            }
+
+            renderer.RenderLinesAfter(obj);
         }
     }
 }

--- a/GlogGenerator/MarkdownExtensions/GlogAutoLinkInlineParser.cs
+++ b/GlogGenerator/MarkdownExtensions/GlogAutoLinkInlineParser.cs
@@ -70,6 +70,7 @@ namespace GlogGenerator.MarkdownExtensions
 
                         var glogLinkInline = new GlogLinkInline()
                         {
+                            IsAutoLink = true,
                             ReferenceType = referenceType,
                             ReferenceKey = referenceKey,
                             // TODO?: would filling in Span, Row, and Column accomplish anything?

--- a/GlogGenerator/MarkdownExtensions/GlogAutoLinkInlineParser.cs
+++ b/GlogGenerator/MarkdownExtensions/GlogAutoLinkInlineParser.cs
@@ -25,8 +25,6 @@ namespace GlogGenerator.MarkdownExtensions
 
         public override bool Match(InlineProcessor processor, ref StringSlice slice)
         {
-            var matchResult = false;
-
             if (slice.CurrentChar == '<')
             {
                 foreach (var linkMatchHandler in this.linkMatchTypes)
@@ -82,19 +80,12 @@ namespace GlogGenerator.MarkdownExtensions
                         processor.Inline = glogLinkInline;
 
                         slice.Start = referenceEndPos + 1;
-                        matchResult = true;
-                        break;
+                        return true;
                     }
                 }
             }
 
-            // If this parser didn't detect a special link, fall-back to the builtin parser.
-            if (!matchResult)
-            {
-                matchResult = base.Match(processor, ref slice);
-            }
-
-            return matchResult;
+            return false;
         }
     }
 }

--- a/GlogGenerator/MarkdownExtensions/GlogLinkHandlers.cs
+++ b/GlogGenerator/MarkdownExtensions/GlogLinkHandlers.cs
@@ -7,7 +7,7 @@ namespace GlogGenerator.MarkdownExtensions
 {
     public static class GlogLinkHandlers
     {
-        public static readonly Dictionary<string, Func<SiteDataIndex, SiteState, string, string>> LinkMatchHandlers = new Dictionary<string, Func<SiteDataIndex, SiteState, string, string>>()
+        public static readonly Dictionary<string, Func<ISiteDataIndex, SiteState, string, string>> LinkMatchHandlers = new Dictionary<string, Func<ISiteDataIndex, SiteState, string, string>>()
         {
             { "category", GetPermalinkForCategoryName },
             { "game", GetPermalinkForGameName },
@@ -28,7 +28,7 @@ namespace GlogGenerator.MarkdownExtensions
             return true;
         }
 
-        public static string GetPermalinkForCategoryName(SiteDataIndex siteDataIndex, SiteState site, string categoryName)
+        public static string GetPermalinkForCategoryName(ISiteDataIndex siteDataIndex, SiteState site, string categoryName)
         {
             var referenceUrlized = UrlizedString.Urlize(categoryName);
             _ = ValidateSiteHasContentForLink(site, "category", referenceUrlized);
@@ -36,9 +36,9 @@ namespace GlogGenerator.MarkdownExtensions
             return $"{site.BaseURL}category/{referenceUrlized}";
         }
 
-        public static string GetPermalinkForGameName(SiteDataIndex siteDataIndex, SiteState site, string gameName)
+        public static string GetPermalinkForGameName(ISiteDataIndex siteDataIndex, SiteState site, string gameName)
         {
-            _ = siteDataIndex.ValidateMatchingGameName(gameName);
+            _ = siteDataIndex.GetGame(gameName);
 
             var referenceUrlized = UrlizedString.Urlize(gameName);
             _ = ValidateSiteHasContentForLink(site, "game", referenceUrlized);
@@ -46,9 +46,9 @@ namespace GlogGenerator.MarkdownExtensions
             return $"{site.BaseURL}game/{referenceUrlized}";
         }
 
-        public static string GetPermalinkForPlatformAbbreviation(SiteDataIndex siteDataIndex, SiteState site, string platformAbbreviation)
+        public static string GetPermalinkForPlatformAbbreviation(ISiteDataIndex siteDataIndex, SiteState site, string platformAbbreviation)
         {
-            _ = siteDataIndex.ValidateMatchingPlatformAbbreviation(platformAbbreviation);
+            _ = siteDataIndex.GetPlatform(platformAbbreviation);
 
             var referenceUrlized = UrlizedString.Urlize(platformAbbreviation);
             _ = ValidateSiteHasContentForLink(site, "platform", referenceUrlized);
@@ -56,7 +56,7 @@ namespace GlogGenerator.MarkdownExtensions
             return $"{site.BaseURL}platform/{referenceUrlized}";
         }
 
-        public static string GetPermalinkForRatingName(SiteDataIndex siteDataIndex, SiteState site, string ratingName)
+        public static string GetPermalinkForRatingName(ISiteDataIndex siteDataIndex, SiteState site, string ratingName)
         {
             var referenceUrlized = UrlizedString.Urlize(ratingName);
             _ = ValidateSiteHasContentForLink(site, "rating", referenceUrlized);
@@ -64,9 +64,9 @@ namespace GlogGenerator.MarkdownExtensions
             return $"{site.BaseURL}rating/{referenceUrlized}";
         }
 
-        public static string GetPermalinkForTagName(SiteDataIndex siteDataIndex, SiteState site, string tagName)
+        public static string GetPermalinkForTagName(ISiteDataIndex siteDataIndex, SiteState site, string tagName)
         {
-            _ = siteDataIndex.ValidateMatchingTagName(tagName);
+            _ = siteDataIndex.GetTag(tagName);
 
             var referenceUrlized = UrlizedString.Urlize(tagName);
             _ = ValidateSiteHasContentForLink(site, "tag", referenceUrlized);

--- a/GlogGenerator/MarkdownExtensions/GlogLinkHtmlRenderer.cs
+++ b/GlogGenerator/MarkdownExtensions/GlogLinkHtmlRenderer.cs
@@ -7,13 +7,13 @@ using Markdig.Syntax.Inlines;
 
 namespace GlogGenerator.MarkdownExtensions
 {
-    public class GlogLinkInlineRenderer : HtmlObjectRenderer<GlogLinkInline>
+    public class GlogLinkHtmlRenderer : HtmlObjectRenderer<GlogLinkInline>
     {
         private readonly LinkInlineRenderer linkInlineRenderer;
         private readonly ISiteDataIndex siteDataIndex;
         private readonly SiteState siteState;
 
-        public GlogLinkInlineRenderer(
+        public GlogLinkHtmlRenderer(
             LinkInlineRenderer linkInlineRenderer,
             ISiteDataIndex siteDataIndex,
             SiteState siteState)

--- a/GlogGenerator/MarkdownExtensions/GlogLinkInlineParser.cs
+++ b/GlogGenerator/MarkdownExtensions/GlogLinkInlineParser.cs
@@ -24,8 +24,6 @@ namespace GlogGenerator.MarkdownExtensions
 
         public override bool Match(InlineProcessor processor, ref StringSlice slice)
         {
-            var matchResult = false;
-
             if (slice.CurrentChar == ']')
             {
                 foreach (var linkMatchHandler in this.linkMatchTypes)
@@ -89,19 +87,12 @@ namespace GlogGenerator.MarkdownExtensions
                         glogLinkInline.IsClosed = true;
 
                         slice.Start = referenceEndPos + 1;
-                        matchResult = true;
-                        break;
+                        return true;
                     }
                 }
             }
 
-            // If this parser didn't detect a special link, fall-back to the builtin parser.
-            if (!matchResult)
-            {
-                matchResult = base.Match(processor, ref slice);
-            }
-
-            return matchResult;
+            return false;
         }
     }
 }

--- a/GlogGenerator/MarkdownExtensions/GlogLinkInlineRenderer.cs
+++ b/GlogGenerator/MarkdownExtensions/GlogLinkInlineRenderer.cs
@@ -10,12 +10,12 @@ namespace GlogGenerator.MarkdownExtensions
     public class GlogLinkInlineRenderer : HtmlObjectRenderer<GlogLinkInline>
     {
         private readonly LinkInlineRenderer linkInlineRenderer;
-        private readonly SiteDataIndex siteDataIndex;
+        private readonly ISiteDataIndex siteDataIndex;
         private readonly SiteState siteState;
 
         public GlogLinkInlineRenderer(
             LinkInlineRenderer linkInlineRenderer,
-            SiteDataIndex siteDataIndex,
+            ISiteDataIndex siteDataIndex,
             SiteState siteState)
         {
             this.linkInlineRenderer = linkInlineRenderer;

--- a/GlogGenerator/MarkdownExtensions/GlogLinkNormalizeRenderer.cs
+++ b/GlogGenerator/MarkdownExtensions/GlogLinkNormalizeRenderer.cs
@@ -1,0 +1,36 @@
+﻿using Markdig.Renderers;
+using Markdig.Renderers.Normalize;
+using Markdig.Syntax.Inlines;
+using System.Text;
+
+namespace GlogGenerator.MarkdownExtensions
+{
+    public class GlogLinkNormalizeRenderer : NormalizeObjectRenderer<GlogLinkInline>
+    {
+        protected override void Write(NormalizeRenderer renderer, GlogLinkInline obj)
+        {
+            var stringBuilder = new StringBuilder();
+            if (obj.IsAutoLink)
+            {
+                stringBuilder.Append('<');
+                stringBuilder.Append(obj.ReferenceType);
+                stringBuilder.Append(':');
+                stringBuilder.Append(obj.ReferenceKey);
+                stringBuilder.Append('>');
+            }
+            else
+            {
+                renderer.Write('[');
+                renderer.WriteChildren(obj);
+
+                stringBuilder.Append("](");
+                stringBuilder.Append(obj.ReferenceType);
+                stringBuilder.Append(':');
+                stringBuilder.Append(obj.ReferenceKey);
+                stringBuilder.Append(')');
+            }
+
+            renderer.Write(stringBuilder.ToString());
+        }
+    }
+}

--- a/GlogGenerator/MarkdownExtensions/GlogLinkRoundtripRenderer.cs
+++ b/GlogGenerator/MarkdownExtensions/GlogLinkRoundtripRenderer.cs
@@ -1,0 +1,36 @@
+﻿using Markdig.Renderers;
+using Markdig.Renderers.Roundtrip;
+using Markdig.Syntax.Inlines;
+using System.Text;
+
+namespace GlogGenerator.MarkdownExtensions
+{
+    public class GlogLinkRoundtripRenderer : RoundtripObjectRenderer<GlogLinkInline>
+    {
+        protected override void Write(RoundtripRenderer renderer, GlogLinkInline obj)
+        {
+            var stringBuilder = new StringBuilder();
+            if (obj.IsAutoLink)
+            {
+                stringBuilder.Append('<');
+                stringBuilder.Append(obj.ReferenceType);
+                stringBuilder.Append(':');
+                stringBuilder.Append(obj.ReferenceKey);
+                stringBuilder.Append('>');
+            }
+            else
+            {
+                renderer.Write('[');
+                renderer.WriteChildren(obj);
+
+                stringBuilder.Append("](");
+                stringBuilder.Append(obj.ReferenceType);
+                stringBuilder.Append(':');
+                stringBuilder.Append(obj.ReferenceKey);
+                stringBuilder.Append(')');
+            }
+
+            renderer.Write(stringBuilder.ToString());
+        }
+    }
+}

--- a/GlogGenerator/MarkdownExtensions/GlogMarkdownExtension.cs
+++ b/GlogGenerator/MarkdownExtensions/GlogMarkdownExtension.cs
@@ -7,6 +7,8 @@ using Markdig.Parsers;
 using Markdig.Parsers.Inlines;
 using Markdig.Renderers;
 using Markdig.Renderers.Html.Inlines;
+using Markdig.Renderers.Normalize;
+using Markdig.Renderers.Roundtrip;
 using Markdig.Syntax;
 using Markdig.Syntax.Inlines;
 
@@ -82,16 +84,24 @@ namespace GlogGenerator.MarkdownExtensions
                             (o as LiteralInline).Content = new StringSlice(substitutedString);
                         }
                     });
+
+                renderer.ObjectRenderers.InsertBefore<LinkInlineRenderer>(
+                    new GlogLinkInlineRenderer(
+                        renderer.ObjectRenderers.Find<LinkInlineRenderer>(),
+                        this.siteDataIndex,
+                        this.siteState));
+
+                renderer.ObjectRenderers.AddIfNotAlready(new FencedDataBlockRenderer(this.siteDataIndex, this.htmlRendererContext));
+                renderer.ObjectRenderers.AddIfNotAlready<SpoilerHtmlRenderer>();
             }
-
-            renderer.ObjectRenderers.InsertBefore<LinkInlineRenderer>(
-                new GlogLinkInlineRenderer(
-                    renderer.ObjectRenderers.Find<LinkInlineRenderer>(),
-                    this.siteDataIndex,
-                    this.siteState));
-
-            renderer.ObjectRenderers.AddIfNotAlready(new FencedDataBlockRenderer(this.siteDataIndex, this.htmlRendererContext));
-            renderer.ObjectRenderers.AddIfNotAlready<SpoilerRenderer>();
+            else if (renderer is NormalizeRenderer)
+            {
+                renderer.ObjectRenderers.AddIfNotAlready<SpoilerNormalizeRenderer>();
+            }
+            else if (renderer is RoundtripRenderer)
+            {
+                renderer.ObjectRenderers.AddIfNotAlready<SpoilerRoundtripRenderer>();
+            }
         }
     }
 }

--- a/GlogGenerator/MarkdownExtensions/GlogMarkdownExtension.cs
+++ b/GlogGenerator/MarkdownExtensions/GlogMarkdownExtension.cs
@@ -41,12 +41,8 @@ namespace GlogGenerator.MarkdownExtensions
 
         public void Setup(MarkdownPipelineBuilder pipeline)
         {
-            // Our custom-links parser can't coexist with the built-in parsers;
-            // We need to replace them, and re-use the base parsers as appropriate.
-            pipeline.InlineParsers.TryRemove<AutolinkInlineParser>();
-            pipeline.InlineParsers.AddIfNotAlready<GlogAutoLinkInlineParser>();
-            pipeline.InlineParsers.TryRemove<LinkInlineParser>();
-            pipeline.InlineParsers.AddIfNotAlready<GlogLinkInlineParser>();
+            pipeline.InlineParsers.InsertBefore<AutolinkInlineParser>(new GlogAutoLinkInlineParser());
+            pipeline.InlineParsers.InsertBefore<LinkInlineParser>(new GlogLinkInlineParser());
 
             pipeline.BlockParsers.AddIfNotAlready<FencedDataBlockParser>();
             pipeline.BlockParsers.AddIfNotAlready<TomlFrontMatterBlockParser>();

--- a/GlogGenerator/MarkdownExtensions/GlogMarkdownExtension.cs
+++ b/GlogGenerator/MarkdownExtensions/GlogMarkdownExtension.cs
@@ -8,6 +8,7 @@ using Markdig.Parsers.Inlines;
 using Markdig.Renderers;
 using Markdig.Renderers.Html.Inlines;
 using Markdig.Renderers.Normalize;
+using Markdig.Renderers.Normalize.Inlines;
 using Markdig.Renderers.Roundtrip;
 using Markdig.Syntax;
 using Markdig.Syntax.Inlines;
@@ -81,9 +82,9 @@ namespace GlogGenerator.MarkdownExtensions
                         }
                     });
 
-                renderer.ObjectRenderers.InsertBefore<LinkInlineRenderer>(
-                    new GlogLinkInlineRenderer(
-                        renderer.ObjectRenderers.Find<LinkInlineRenderer>(),
+                renderer.ObjectRenderers.InsertBefore<Markdig.Renderers.Html.Inlines.LinkInlineRenderer>(
+                    new GlogLinkHtmlRenderer(
+                        renderer.ObjectRenderers.Find<Markdig.Renderers.Html.Inlines.LinkInlineRenderer>(),
                         this.siteDataIndex,
                         this.siteState));
 
@@ -92,10 +93,12 @@ namespace GlogGenerator.MarkdownExtensions
             }
             else if (renderer is NormalizeRenderer)
             {
+                renderer.ObjectRenderers.InsertBefore<Markdig.Renderers.Normalize.Inlines.AutolinkInlineRenderer>(new GlogLinkNormalizeRenderer());
                 renderer.ObjectRenderers.AddIfNotAlready<SpoilerNormalizeRenderer>();
             }
             else if (renderer is RoundtripRenderer)
             {
+                renderer.ObjectRenderers.InsertBefore<Markdig.Renderers.Roundtrip.Inlines.AutolinkInlineRenderer>(new GlogLinkRoundtripRenderer());
                 renderer.ObjectRenderers.AddIfNotAlready<SpoilerRoundtripRenderer>();
             }
         }

--- a/GlogGenerator/MarkdownExtensions/GlogMarkdownExtension.cs
+++ b/GlogGenerator/MarkdownExtensions/GlogMarkdownExtension.cs
@@ -10,6 +10,7 @@ using Markdig.Renderers.Html.Inlines;
 using Markdig.Renderers.Normalize;
 using Markdig.Renderers.Normalize.Inlines;
 using Markdig.Renderers.Roundtrip;
+using Markdig.Renderers.Roundtrip.Inlines;
 using Markdig.Syntax;
 using Markdig.Syntax.Inlines;
 
@@ -100,6 +101,9 @@ namespace GlogGenerator.MarkdownExtensions
             {
                 renderer.ObjectRenderers.InsertBefore<Markdig.Renderers.Roundtrip.Inlines.AutolinkInlineRenderer>(new GlogLinkRoundtripRenderer());
                 renderer.ObjectRenderers.AddIfNotAlready<SpoilerRoundtripRenderer>();
+
+                // The built-in roundtrip renderer for LinkInline doesn't work! so, replace it.
+                renderer.ObjectRenderers.Replace<Markdig.Renderers.Roundtrip.Inlines.LinkInlineRenderer>(new LinkInlineRoundtripRenderer());
             }
         }
     }

--- a/GlogGenerator/MarkdownExtensions/GlogMarkdownExtension.cs
+++ b/GlogGenerator/MarkdownExtensions/GlogMarkdownExtension.cs
@@ -49,6 +49,11 @@ namespace GlogGenerator.MarkdownExtensions
             pipeline.BlockParsers.AddIfNotAlready<FencedDataBlockParser>();
             pipeline.BlockParsers.AddIfNotAlready<TomlFrontMatterBlockParser>();
 
+            // Markdig offers an extension for "extra" list item bullet-type parsing,
+            // but it doesn't work totally right for roundtrip rendering, so use a custom parser.
+            var listParser = pipeline.BlockParsers.FindExact<ListBlockParser>();
+            listParser.ItemParsers.AddIfNotAlready<ListExtraItemBulletParser>();
+
             // The built-in quote block parser will steal '>' at the beginning of a line.
             // We need a customization to not-steal it when followed by '!' for spoilers.
             pipeline.BlockParsers.TryRemove<QuoteBlockParser>();

--- a/GlogGenerator/MarkdownExtensions/GlogMarkdownExtension.cs
+++ b/GlogGenerator/MarkdownExtensions/GlogMarkdownExtension.cs
@@ -120,6 +120,8 @@ namespace GlogGenerator.MarkdownExtensions
 
                 // The built-in roundtrip renderer for LinkInline doesn't work! so, replace it.
                 renderer.ObjectRenderers.Replace<Markdig.Renderers.Roundtrip.Inlines.LinkInlineRenderer>(new LinkInlineRoundtripRenderer());
+
+                renderer.ObjectRenderers.AddIfNotAlready<TomlFronMatterBlockRoundtripeRenderer>();
             }
         }
     }

--- a/GlogGenerator/MarkdownExtensions/GlogMarkdownExtension.cs
+++ b/GlogGenerator/MarkdownExtensions/GlogMarkdownExtension.cs
@@ -17,14 +17,14 @@ namespace GlogGenerator.MarkdownExtensions
     public class GlogMarkdownExtension : IMarkdownExtension
     {
         private readonly SiteBuilder siteBuilder;
-        private readonly SiteDataIndex siteDataIndex;
+        private readonly ISiteDataIndex siteDataIndex;
         private readonly SiteState siteState;
 
         private HtmlRendererContext htmlRendererContext;
 
         public GlogMarkdownExtension(
             SiteBuilder siteBuilder,
-            SiteDataIndex siteDataIndex,
+            ISiteDataIndex siteDataIndex,
             SiteState siteState)
         {
             this.siteBuilder = siteBuilder;

--- a/GlogGenerator/MarkdownExtensions/GlogMarkdownExtension.cs
+++ b/GlogGenerator/MarkdownExtensions/GlogMarkdownExtension.cs
@@ -100,12 +100,13 @@ namespace GlogGenerator.MarkdownExtensions
                         this.siteDataIndex,
                         this.siteState));
 
-                renderer.ObjectRenderers.AddIfNotAlready(new FencedDataBlockRenderer(this.siteDataIndex, this.htmlRendererContext));
+                renderer.ObjectRenderers.AddIfNotAlready(new FencedDataBlockHtmlRenderer(this.siteDataIndex, this.htmlRendererContext));
                 renderer.ObjectRenderers.AddIfNotAlready<SpoilerHtmlRenderer>();
             }
             else if (renderer is NormalizeRenderer)
             {
                 renderer.ObjectRenderers.InsertBefore<Markdig.Renderers.Normalize.Inlines.AutolinkInlineRenderer>(new GlogLinkNormalizeRenderer());
+                renderer.ObjectRenderers.AddIfNotAlready<FencedDataBlockNormalizeRenderer>();
                 renderer.ObjectRenderers.AddIfNotAlready<SpoilerNormalizeRenderer>();
 
                 // The built-in normalize renderer is missing generic attributes, so, replace it.
@@ -114,6 +115,7 @@ namespace GlogGenerator.MarkdownExtensions
             else if (renderer is RoundtripRenderer)
             {
                 renderer.ObjectRenderers.InsertBefore<Markdig.Renderers.Roundtrip.Inlines.AutolinkInlineRenderer>(new GlogLinkRoundtripRenderer());
+                renderer.ObjectRenderers.AddIfNotAlready<FencedDataBlockRoundtripeRenderer>();
                 renderer.ObjectRenderers.AddIfNotAlready<SpoilerRoundtripRenderer>();
 
                 // The built-in roundtrip renderer for LinkInline doesn't work! so, replace it.

--- a/GlogGenerator/MarkdownExtensions/IMarkdownObjectExtensions.cs
+++ b/GlogGenerator/MarkdownExtensions/IMarkdownObjectExtensions.cs
@@ -1,0 +1,20 @@
+using Markdig.Renderers.Html;
+using Markdig.Syntax;
+
+namespace GlogGenerator.MarkdownExtensions
+{
+    public static class IMarkdownObjectExtensions
+    {
+        private static readonly object ReversibleGenericAttributesKey = typeof(ReversibleGenericAttributes);
+
+        public static ReversibleGenericAttributes TryGetReversibleGenericAttributes(this IMarkdownObject obj)
+        {
+            return obj.GetData(ReversibleGenericAttributesKey) as ReversibleGenericAttributes;
+        }
+
+        public static void SetReversibleGenericAttributes(this IMarkdownObject obj, ReversibleGenericAttributes attributes)
+        {
+            obj.SetData(ReversibleGenericAttributesKey, attributes);
+        }
+    }
+}

--- a/GlogGenerator/MarkdownExtensions/IMarkdownObjectExtensions.cs
+++ b/GlogGenerator/MarkdownExtensions/IMarkdownObjectExtensions.cs
@@ -6,15 +6,26 @@ namespace GlogGenerator.MarkdownExtensions
     public static class IMarkdownObjectExtensions
     {
         private static readonly object ReversibleGenericAttributesKey = typeof(ReversibleGenericAttributes);
+        private static readonly object RoundtripOriginalSourceKey = typeof(RoundtripOriginalSource);
 
         public static ReversibleGenericAttributes TryGetReversibleGenericAttributes(this IMarkdownObject obj)
         {
             return obj.GetData(ReversibleGenericAttributesKey) as ReversibleGenericAttributes;
         }
 
+        public static RoundtripOriginalSource TryGetRoundtripOriginalSource(this IMarkdownObject obj)
+        {
+            return obj.GetData(RoundtripOriginalSourceKey) as RoundtripOriginalSource;
+        }
+
         public static void SetReversibleGenericAttributes(this IMarkdownObject obj, ReversibleGenericAttributes attributes)
         {
             obj.SetData(ReversibleGenericAttributesKey, attributes);
+        }
+
+        public static void SetRoundtripOriginalSource(this IMarkdownObject obj, RoundtripOriginalSource source)
+        {
+            obj.SetData(RoundtripOriginalSourceKey, source);
         }
     }
 }

--- a/GlogGenerator/MarkdownExtensions/LinkInlineRoundtripRenderer.cs
+++ b/GlogGenerator/MarkdownExtensions/LinkInlineRoundtripRenderer.cs
@@ -1,0 +1,51 @@
+using Markdig.Renderers.Roundtrip;
+using Markdig.Syntax.Inlines;
+
+namespace GlogGenerator.MarkdownExtensions
+{
+    public class LinkInlineRoundtripRenderer : RoundtripObjectRenderer<LinkInline>
+    {
+        protected override void Write(RoundtripRenderer renderer, LinkInline obj)
+        {
+            if (obj.IsImage)
+            {
+                renderer.Write('!');
+            }
+            // link text
+            renderer.Write('[');
+            renderer.WriteChildren(obj);
+            renderer.Write(']');
+
+            if (obj.Label != null)
+            {
+                if (obj.LocalLabel == LocalLabel.Local || obj.LocalLabel == LocalLabel.Empty)
+                {
+                    renderer.Write('[');
+                    if (obj.LocalLabel == LocalLabel.Local)
+                    {
+                        renderer.Write(obj.LabelWithTrivia);
+                    }
+                    renderer.Write(']');
+                }
+            }
+            else
+            {
+                if (obj.Url != null)
+                {
+                    // Bugfix: the built-in roundtrip renderer for LinkInline never actually writes the URL.
+                    // This corrected rendering behavior is adapted from the normalize renderer, instead.
+                    renderer.Write('(').Write(obj.Url);
+
+                    if (obj.Title is { Length: > 0 })
+                    {
+                        renderer.Write(" \"");
+                        renderer.Write(obj.Title.Replace(@"""", @"\"""));
+                        renderer.Write('"');
+                    }
+
+                    renderer.Write(')');
+                }
+            }
+        }
+    }
+}

--- a/GlogGenerator/MarkdownExtensions/ListExtraItemBulletsParser.cs
+++ b/GlogGenerator/MarkdownExtensions/ListExtraItemBulletsParser.cs
@@ -1,0 +1,31 @@
+using Markdig.Extensions.ListExtras;
+using Markdig.Helpers;
+using Markdig.Parsers;
+
+namespace GlogGenerator.MarkdownExtensions
+{
+    public class ListExtraItemBulletParser : ListExtraItemParser
+    {
+        public ListExtraItemBulletParser() : base() { }
+
+        public override bool TryParse(BlockProcessor state, char pendingBulletType, out ListInfo result)
+        {
+            var originalSlice = state.Line;
+            var parsed = base.TryParse(state, pendingBulletType, out result);
+
+            if (parsed)
+            {
+                // Bugfix: set the list item's SourceBullet so that it can be roundtrip rendered.
+                var sourceBullet = new StringSlice(originalSlice.Text, originalSlice.Start, state.Start - 1);
+                if (sourceBullet.PeekCharAbsolute(sourceBullet.End) == result.OrderedDelimiter)
+                {
+                    sourceBullet.End--;
+                }
+
+                result.SourceBullet = sourceBullet;
+            }
+
+            return parsed;
+        }
+    }
+}

--- a/GlogGenerator/MarkdownExtensions/MarkdownDocumentExtensions.cs
+++ b/GlogGenerator/MarkdownExtensions/MarkdownDocumentExtensions.cs
@@ -1,0 +1,28 @@
+using System.IO;
+using Markdig;
+using Markdig.Renderers.Roundtrip;
+using Markdig.Syntax;
+
+namespace GlogGenerator.MarkdownExtensions
+{
+    public static class MarkdownDocumentExtensions
+    {
+        public static string ToMarkdownString(this MarkdownDocument mdDoc, MarkdownPipeline pipeline = null)
+        {
+            string roundtrip;
+            using (var mdTextWriter = new StringWriter())
+            {
+                var mdRenderer = new RoundtripRenderer(mdTextWriter);
+                if (pipeline != null)
+                {
+                    pipeline.Setup(mdRenderer);
+                }
+
+                mdRenderer.Render(mdDoc);
+                roundtrip = mdTextWriter.ToString();
+            }
+
+            return roundtrip;
+        }
+    }
+}

--- a/GlogGenerator/MarkdownExtensions/ReversibleGenericAttributes.cs
+++ b/GlogGenerator/MarkdownExtensions/ReversibleGenericAttributes.cs
@@ -1,0 +1,17 @@
+namespace GlogGenerator.MarkdownExtensions
+{
+    public class ReversibleGenericAttributes
+    {
+        private string originalString;
+
+        public ReversibleGenericAttributes(string originalString)
+        {
+            this.originalString = originalString;
+        }
+
+        public string GetOriginalString()
+        {
+            return this.originalString;
+        }
+    }
+}

--- a/GlogGenerator/MarkdownExtensions/ReversibleGenericAttributesParser.cs
+++ b/GlogGenerator/MarkdownExtensions/ReversibleGenericAttributesParser.cs
@@ -1,0 +1,62 @@
+using Markdig.Extensions.GenericAttributes;
+using Markdig.Helpers;
+using Markdig.Parsers;
+using Markdig.Renderers.Html;
+using Markdig.Syntax;
+
+namespace GlogGenerator.MarkdownExtensions
+{
+    public class ReversibleGenericAttributesParser : GenericAttributesParser
+    {
+        public ReversibleGenericAttributesParser() : base() { }
+
+        public override bool Match(InlineProcessor processor, ref StringSlice slice)
+        {
+            var attrStartPos = slice.Start;
+            var matched = base.Match(processor, ref slice);
+            if (matched)
+            {
+                var attrEndPos = slice.Start;
+                var attrString = slice.Text.Substring(attrStartPos, attrEndPos - attrStartPos);
+                var attr = new ReversibleGenericAttributes(attrString);
+
+                // TODO?: is this always the right element?
+                processor.Inline.SetReversibleGenericAttributes(attr);
+            }
+
+            return matched;
+        }
+
+        // Extracted from Markdig's GenericAttributesExtension
+        public static bool TryProcessAttributesForHeading(BlockProcessor processor, ref StringSlice line, IBlock block)
+        {
+            // Try to find if there is any attributes { in the info string on the first line of a FencedCodeBlock
+            if (line.Start < line.End)
+            {
+                int indexOfAttributes = line.IndexOf('{');
+                if (indexOfAttributes >= 0)
+                {
+                    // Work on a copy
+                    var copy = line;
+                    copy.Start = indexOfAttributes;
+                    var startOfAttributes = copy.Start;
+                    if (GenericAttributesParser.TryParse(ref copy, out HtmlAttributes attributes))
+                    {
+                        var htmlAttributes = block.GetAttributes();
+                        attributes.CopyTo(htmlAttributes);
+
+                        // Update position for HtmlAttributes
+                        htmlAttributes.Line = processor.LineIndex;
+                        htmlAttributes.Column = startOfAttributes - processor.CurrentLineStartPosition; // This is not accurate with tabs!
+                        htmlAttributes.Span.Start = startOfAttributes;
+                        htmlAttributes.Span.End = copy.Start - 1;
+
+                        line.End = indexOfAttributes - 1;
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/GlogGenerator/MarkdownExtensions/ReversiblePipeTableParser.cs
+++ b/GlogGenerator/MarkdownExtensions/ReversiblePipeTableParser.cs
@@ -1,0 +1,43 @@
+using Markdig.Extensions.Tables;
+using Markdig.Helpers;
+using Markdig.Parsers;
+using Markdig.Parsers.Inlines;
+using Markdig.Syntax.Inlines;
+
+namespace GlogGenerator.MarkdownExtensions
+{
+    public class ReversiblePipeTableParser : PipeTableParser, IPostInlineProcessor
+    {
+        public ReversiblePipeTableParser(LineBreakInlineParser lineBreakParser, PipeTableOptions options = null)
+            : base(lineBreakParser, options) { }
+
+        public override bool Match(InlineProcessor processor, ref StringSlice slice)
+        {
+            var originalSlice = slice;
+            var matched = base.Match(processor, ref slice);
+            if (matched && processor.Block != null)
+            {
+                var alreadySetOriginalSource = (processor.Block.TryGetRoundtripOriginalSource() != null);
+                if (!alreadySetOriginalSource)
+                {
+                    processor.Block.SetRoundtripOriginalSource(new RoundtripOriginalSource(originalSlice));
+                }
+            }
+
+            return matched;
+        }
+
+        public new bool PostProcess(InlineProcessor state, Inline root, Inline lastChild, int postInlineProcessorIndex, bool isFinalProcessing)
+        {
+            var shouldContinue = base.PostProcess(state, root, lastChild, postInlineProcessorIndex, isFinalProcessing);
+
+            if (isFinalProcessing && state.BlockNew is Table table)
+            {
+                var originalSource = state.Block?.TryGetRoundtripOriginalSource();
+                table.SetRoundtripOriginalSource(originalSource);
+            }
+
+            return shouldContinue;
+        }
+    }
+}

--- a/GlogGenerator/MarkdownExtensions/ReversiblePipeTableParser.cs
+++ b/GlogGenerator/MarkdownExtensions/ReversiblePipeTableParser.cs
@@ -35,6 +35,13 @@ namespace GlogGenerator.MarkdownExtensions
             {
                 var originalSource = state.Block?.TryGetRoundtripOriginalSource();
                 table.SetRoundtripOriginalSource(originalSource);
+
+                // Bugfix: the built-in postprocessing drops newlines after the original markup.
+                if (state.Block != null)
+                {
+                    state.BlockNew.NewLine = state.Block.NewLine;
+                    state.BlockNew.LinesAfter = state.Block.LinesAfter;
+                }
             }
 
             return shouldContinue;

--- a/GlogGenerator/MarkdownExtensions/ReversiblePipeTableRoundtripRenderer.cs
+++ b/GlogGenerator/MarkdownExtensions/ReversiblePipeTableRoundtripRenderer.cs
@@ -1,0 +1,17 @@
+﻿using Markdig.Extensions.Tables;
+using Markdig.Renderers.Roundtrip;
+
+namespace GlogGenerator.MarkdownExtensions
+{
+    public class ReversibleTableRoundtripRenderer : RoundtripObjectRenderer<Table>
+    {
+        protected override void Write(RoundtripRenderer renderer, Table obj)
+        {
+            var originalSource = obj.TryGetRoundtripOriginalSource();
+            if (originalSource != null)
+            {
+                renderer.Write(originalSource.GetOriginalString());
+            }
+        }
+    }
+}

--- a/GlogGenerator/MarkdownExtensions/ReversiblePipeTableRoundtripRenderer.cs
+++ b/GlogGenerator/MarkdownExtensions/ReversiblePipeTableRoundtripRenderer.cs
@@ -1,4 +1,5 @@
 ﻿using Markdig.Extensions.Tables;
+using Markdig.Helpers;
 using Markdig.Renderers.Roundtrip;
 
 namespace GlogGenerator.MarkdownExtensions
@@ -7,11 +8,24 @@ namespace GlogGenerator.MarkdownExtensions
     {
         protected override void Write(RoundtripRenderer renderer, Table obj)
         {
+            renderer.RenderLinesBefore(obj);
+
+            renderer.Write(obj.TriviaBefore);
+
             var originalSource = obj.TryGetRoundtripOriginalSource();
             if (originalSource != null)
             {
                 renderer.Write(originalSource.GetOriginalString());
             }
+
+            renderer.Write(obj.TriviaAfter);
+
+            if (obj.NewLine != NewLine.None)
+            {
+                renderer.Write(obj.NewLine.AsString());
+            }
+
+            renderer.RenderLinesAfter(obj);
         }
     }
 }

--- a/GlogGenerator/MarkdownExtensions/RoundtripOriginalSource.cs
+++ b/GlogGenerator/MarkdownExtensions/RoundtripOriginalSource.cs
@@ -1,0 +1,19 @@
+using Markdig.Helpers;
+
+namespace GlogGenerator.MarkdownExtensions
+{
+    public class RoundtripOriginalSource
+    {
+        private string originalString;
+
+        public RoundtripOriginalSource(StringSlice slice)
+        {
+            this.originalString = slice.ToString();
+        }
+
+        public string GetOriginalString()
+        {
+            return this.originalString;
+        }
+    }
+}

--- a/GlogGenerator/MarkdownExtensions/SpoilerHtmlRenderer.cs
+++ b/GlogGenerator/MarkdownExtensions/SpoilerHtmlRenderer.cs
@@ -4,7 +4,7 @@ using Markdig.Renderers.Html;
 
 namespace GlogGenerator.MarkdownExtensions
 {
-    public class SpoilerRenderer : HtmlObjectRenderer<SpoilerInline>
+    public class SpoilerHtmlRenderer : HtmlObjectRenderer<SpoilerInline>
     {
         protected override void Write(HtmlRenderer renderer, SpoilerInline obj)
         {

--- a/GlogGenerator/MarkdownExtensions/SpoilerNormalizeRenderer.cs
+++ b/GlogGenerator/MarkdownExtensions/SpoilerNormalizeRenderer.cs
@@ -1,0 +1,26 @@
+﻿using System.IO;
+using Markdig.Renderers;
+using Markdig.Renderers.Normalize;
+
+namespace GlogGenerator.MarkdownExtensions
+{
+    public class SpoilerNormalizeRenderer : NormalizeObjectRenderer<SpoilerInline>
+    {
+        protected override void Write(NormalizeRenderer renderer, SpoilerInline obj)
+        {
+            switch (obj.InlineType)
+            {
+                case SpoilerInline.SpoilerInlineType.Begin:
+                    renderer.Write(">!");
+                    break;
+
+                case SpoilerInline.SpoilerInlineType.End:
+                    renderer.Write("!<");
+                    break;
+
+                default:
+                    throw new InvalidDataException($"Unrecognized SpoilerInlineType {obj.InlineType}");
+            }
+        }
+    }
+}

--- a/GlogGenerator/MarkdownExtensions/SpoilerRoundtripRenderer.cs
+++ b/GlogGenerator/MarkdownExtensions/SpoilerRoundtripRenderer.cs
@@ -1,0 +1,26 @@
+﻿using System.IO;
+using Markdig.Renderers;
+using Markdig.Renderers.Roundtrip;
+
+namespace GlogGenerator.MarkdownExtensions
+{
+    public class SpoilerRoundtripRenderer : RoundtripObjectRenderer<SpoilerInline>
+    {
+        protected override void Write(RoundtripRenderer renderer, SpoilerInline obj)
+        {
+            switch (obj.InlineType)
+            {
+                case SpoilerInline.SpoilerInlineType.Begin:
+                    renderer.Write(">!");
+                    break;
+
+                case SpoilerInline.SpoilerInlineType.End:
+                    renderer.Write("!<");
+                    break;
+
+                default:
+                    throw new InvalidDataException($"Unrecognized SpoilerInlineType {obj.InlineType}");
+            }
+        }
+    }
+}

--- a/GlogGenerator/MarkdownExtensions/TomlFrontMatterBlockRoundtripRenderer.cs
+++ b/GlogGenerator/MarkdownExtensions/TomlFrontMatterBlockRoundtripRenderer.cs
@@ -1,0 +1,29 @@
+﻿using Markdig.Helpers;
+using Markdig.Renderers.Roundtrip;
+
+namespace GlogGenerator.MarkdownExtensions
+{
+    public class TomlFronMatterBlockRoundtripeRenderer : RoundtripObjectRenderer<TomlFrontMatterBlock>
+    {
+        protected override void Write(RoundtripRenderer renderer, TomlFrontMatterBlock obj)
+        {
+            renderer.Write(obj.TriviaBefore);
+
+            renderer.Write("+++\n");
+            foreach (var line in obj.Lines.Lines)
+            {
+                if (line.Slice.Length > 0)
+                {
+                    renderer.Write(line);
+                }
+                if (line.NewLine != NewLine.None)
+                {
+                    renderer.Write(line.NewLine.AsString());
+                }
+            }
+            renderer.Write("+++\n");
+
+            renderer.Write(obj.TriviaAfter);
+        }
+    }
+}

--- a/GlogGenerator/RenderState/PageState.cs
+++ b/GlogGenerator/RenderState/PageState.cs
@@ -176,15 +176,15 @@ namespace GlogGenerator.RenderState
 
             page.Date = postData.Date;
 
-            page.Games = postData.Games.Select(c => new GameData() { Title = c }).ToList();
+            page.Games = postData.Games?.Select(c => new GameData() { Title = c }).ToList();
 
             page.HideDate = (postData.Date == DateTimeOffset.MinValue);
 
             page.Permalink = $"{siteBuilder.GetBaseURL()}{postData.PermalinkRelative}";
 
-            page.Platforms = postData.Platforms.Select(c => new PlatformData() { Abbreviation = c }).ToList();
+            page.Platforms = postData.Platforms?.Select(c => new PlatformData() { Abbreviation = c }).ToList();
 
-            page.Ratings = postData.Ratings.Select(c => new RatingData() { Name = c }).ToList();
+            page.Ratings = postData.Ratings?.Select(c => new RatingData() { Name = c }).ToList();
 
             page.Title = postData.Title;
 

--- a/GlogGenerator/RenderState/PageState.cs
+++ b/GlogGenerator/RenderState/PageState.cs
@@ -151,7 +151,7 @@ namespace GlogGenerator.RenderState
             page.HideDate = true;
             page.HideTitle = true;
 
-            page.SourceContent = pageData.Content;
+            page.SourceContent = pageData.MdDoc;
 
             page.Permalink = $"{siteBuilder.GetBaseURL()}{pageData.PermalinkRelative}";
 
@@ -188,7 +188,7 @@ namespace GlogGenerator.RenderState
 
             page.Title = postData.Title;
 
-            page.SourceContent = postData.Content;
+            page.SourceContent = postData.MdDoc;
 
             var outputPathRelative = postData.PermalinkRelative;
             if (!outputPathRelative.EndsWith('/'))

--- a/GlogGenerator/SiteBuilder.cs
+++ b/GlogGenerator/SiteBuilder.cs
@@ -111,6 +111,11 @@ namespace GlogGenerator
             this.siteDataIndex.LoadContent(igdbCache);
         }
 
+        public void RewriteData()
+        {
+            this.siteDataIndex.RewriteSourceContent();
+        }
+
         public List<GameStats> GetGameStatsForDateRange(DateTimeOffset startDate, DateTimeOffset endDate)
         {
             var statsByGameAndPlatform = new Dictionary<string, GameStats>();
@@ -206,11 +211,6 @@ namespace GlogGenerator
         public VariableSubstitution GetVariableSubstitution()
         {
             return this.variableSubstitution;
-        }
-
-        public MarkdownDocument ParseMarkdown(string markdown)
-        {
-            return Markdown.Parse(markdown, this.markdownPipeline);
         }
 
         public HtmlRendererContext GetRendererContext()

--- a/GlogGenerator/SiteBuilder.cs
+++ b/GlogGenerator/SiteBuilder.cs
@@ -64,7 +64,6 @@ namespace GlogGenerator
 
             this.markdownPipeline = new MarkdownPipelineBuilder()
                 .Use<ListExtraExtension>()
-                .UseGenericAttributes()
                 .UseMediaLinks()
                 .UsePipeTables()
                 .UseSoftlineBreakAsHardlineBreak()

--- a/GlogGenerator/SiteBuilder.cs
+++ b/GlogGenerator/SiteBuilder.cs
@@ -117,42 +117,48 @@ namespace GlogGenerator
             var reportPosts = this.siteDataIndex.GetPosts().Where(p => p.Date >= startDate && p.Date <= endDate).ToList();
             foreach (var reportPost in reportPosts)
             {
-                foreach (var postGame in reportPost.Games)
+                if (reportPost.Games != null)
                 {
-                    foreach (var postPlatform in reportPost.Platforms)
+                    foreach (var postGame in reportPost.Games)
                     {
-                        var gameAndPlatformKey = $"{postGame}__{postPlatform}";
-
-                        if (!statsByGameAndPlatform.ContainsKey(gameAndPlatformKey))
+                        if (reportPost.Platforms != null)
                         {
-                            var gameData = this.siteDataIndex.GetGame(postGame);
-
-                            statsByGameAndPlatform[gameAndPlatformKey] = new GameStats()
+                            foreach (var postPlatform in reportPost.Platforms)
                             {
-                                Title = postGame,
-                                Platform = postPlatform,
-                                Type = gameData.IgdbCategory.Description(),
-                                FirstPosted = reportPost.Date,
-                                LastPosted = reportPost.Date,
-                            };
-                        }
+                                var gameAndPlatformKey = $"{postGame}__{postPlatform}";
 
-                        if (reportPost.Date < statsByGameAndPlatform[gameAndPlatformKey].FirstPosted)
-                        {
-                            statsByGameAndPlatform[gameAndPlatformKey].FirstPosted = reportPost.Date;
-                        }
+                                if (!statsByGameAndPlatform.ContainsKey(gameAndPlatformKey))
+                                {
+                                    var gameData = this.siteDataIndex.GetGame(postGame);
 
-                        if (reportPost.Date > statsByGameAndPlatform[gameAndPlatformKey].LastPosted)
-                        {
-                            statsByGameAndPlatform[gameAndPlatformKey].LastPosted = reportPost.Date;
-                        }
+                                    statsByGameAndPlatform[gameAndPlatformKey] = new GameStats()
+                                    {
+                                        Title = postGame,
+                                        Platform = postPlatform,
+                                        Type = gameData.IgdbCategory.Description(),
+                                        FirstPosted = reportPost.Date,
+                                        LastPosted = reportPost.Date,
+                                    };
+                                }
 
-                        if (reportPost.Ratings.Count > 0)
-                        {
-                            statsByGameAndPlatform[gameAndPlatformKey].Rating = reportPost.Ratings[0];
-                        }
+                                if (reportPost.Date < statsByGameAndPlatform[gameAndPlatformKey].FirstPosted)
+                                {
+                                    statsByGameAndPlatform[gameAndPlatformKey].FirstPosted = reportPost.Date;
+                                }
 
-                        ++statsByGameAndPlatform[gameAndPlatformKey].NumPosts;
+                                if (reportPost.Date > statsByGameAndPlatform[gameAndPlatformKey].LastPosted)
+                                {
+                                    statsByGameAndPlatform[gameAndPlatformKey].LastPosted = reportPost.Date;
+                                }
+
+                                if (reportPost.Ratings != null && reportPost.Ratings.Count > 0)
+                                {
+                                    statsByGameAndPlatform[gameAndPlatformKey].Rating = reportPost.Ratings[0];
+                                }
+
+                                ++statsByGameAndPlatform[gameAndPlatformKey].NumPosts;
+                            }
+                        }
                     }
                 }
             }
@@ -246,10 +252,13 @@ namespace GlogGenerator
                 {
                     try
                     {
-                        // Verify that the post's games are found in our metadata cache.
-                        foreach (var game in postData.Games)
+                        if (postData.Games != null)
                         {
-                            _ = this.siteDataIndex.GetGame(game);
+                            // Verify that the post's games are found in our metadata cache.
+                            foreach (var game in postData.Games)
+                            {
+                                _ = this.siteDataIndex.GetGame(game);
+                            }
                         }
 
                         var page = PageState.FromPostData(this, postData);

--- a/GlogGenerator/SiteBuilder.cs
+++ b/GlogGenerator/SiteBuilder.cs
@@ -64,7 +64,6 @@ namespace GlogGenerator
 
             this.markdownPipeline = new MarkdownPipelineBuilder()
                 .EnableTrackTrivia()
-                .Use<ListExtraExtension>()
                 .UseMediaLinks()
                 .UsePipeTables()
                 .UseSoftlineBreakAsHardlineBreak()


### PR DESCRIPTION
This includes some net-new "roundtrip" rendering (re-generating markdown from a parsed document) for Glog customizations:
* FencedDataBlock -- granted, this makes a lot of assumptions about uncreative formatting within the fence.
* GlogAutolink and GlogLink.
* Spoilers.
* TomlFrontMatter -- although, because the Tomlyn result's sequence/order appears non-deterministic, the roundtrip behavior simply reuses the original source and won't tolerate post-parse modifications.

And some fixups to Markdig behavior that didn't roundtrip correctly out of the box:
* LinkInline -- a bugfix to include the URL in roundtrips (kind of important!), as well as roundtrip inclusion of Generic Attributes (in `{...}` following the link URL).
* ListExtraItem -- a bugfix to ensure the parser records list item "SourceBullets" for use in the roundtrip.
* PipeTable -- although, because the built-in parsing is missing a lot of "trivia" tracking *and* doesn't seem to record anything about the header-separator row, this roundtrip implementation is (like my TomlFrontMatter one) only respective of the original markup and won't tolerate post-parse modifications.

And most importantly... unit tests!  Which necessitated some SiteBuilder and related re-scaffolding, to make the markdown roundtrip codepath more testable.

There's not a whole lot of coverage on "presumed correct" Markdig roundtrips, but these tests should cover the most significant portions of everything I'm overriding and/or extending.

Manually, I've verified that the new `-w` option to rewrite all content will result in *no changes* to any current Glog content.  (It didn't always match, before I'd fixed some roundtrip behaviors.)

What's next?  Well, this is ultimately in service of rewriting Glog links when an IGDB data update changes a reference key - i.e. a game title or a platform abbreviation is modified - so the next steps toward that are:
* Including some mutable "reference" entity in those markdown link objects, such that an original key will be parsed, a data update will correct the key, and a content rewrite will change the original markdown to fit.
* Some kind of refactor on the Actions pipeline for data updates; unfortunately the current method only works for updating a single file (the IGDB cache), so if markdown content is modified too, I need some new approach to commit or PR those changes.