### PR TITLE
SiteDataReference: consistent references to dynamic entities.

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -32,5 +32,5 @@ jobs:
           TWITCH_CLIENT_SECRET: ${{ secrets.TWITCH_CLIENT_SECRET }}
         run: |
           rm -rf public
-          ./GlogGeneratorBuild/GlogGenerator build -i . -t GlogGeneratorBuild/templates -u true --igdb-client-id jy5t8x2w2eqdc7bax2zx3rlne7eup4 --igdb-client-secret $TWITCH_CLIENT_SECRET -h "https://tsuereth.com" -o public
+          ./GlogGeneratorBuild/GlogGenerator build -i . -t GlogGeneratorBuild/templates -u true --igdb-client-id jy5t8x2w2eqdc7bax2zx3rlne7eup4 --igdb-client-secret $TWITCH_CLIENT_SECRET -w true -h "https://tsuereth.com" -o public
 

--- a/.github/workflows/UpdateDataAndBuildAndDeploy.yml
+++ b/.github/workflows/UpdateDataAndBuildAndDeploy.yml
@@ -35,7 +35,7 @@ jobs:
           TWITCH_CLIENT_SECRET: ${{ secrets.TWITCH_CLIENT_SECRET }}
         run: |
           rm -rf public
-          ./GlogGeneratorBuild/GlogGenerator build -i . -t GlogGeneratorBuild/templates -u true --igdb-client-id jy5t8x2w2eqdc7bax2zx3rlne7eup4 --igdb-client-secret $TWITCH_CLIENT_SECRET -h "https://tsuereth.com" -o public
+          ./GlogGeneratorBuild/GlogGenerator build -i . -t GlogGeneratorBuild/templates -u true --igdb-client-id jy5t8x2w2eqdc7bax2zx3rlne7eup4 --igdb-client-secret $TWITCH_CLIENT_SECRET -w true -h "https://tsuereth.com" -o public
 
       - name: SetupPullRequestValues
         run: |

--- a/GlogGenerator.Test/Data/FakeSiteDataIndex.cs
+++ b/GlogGenerator.Test/Data/FakeSiteDataIndex.cs
@@ -1,0 +1,198 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using GlogGenerator.Data;
+
+namespace GlogGenerator.Test
+{
+    public class FakeSiteDataIndex : ISiteDataIndex
+    {
+        private List<CategoryData> categories = new List<CategoryData>();
+        private List<GameData> games = new List<GameData>();
+        private List<PlatformData> platforms = new List<PlatformData>();
+        private List<RatingData> ratings = new List<RatingData>();
+        private List<TagData> tags = new List<TagData>();
+
+        public T GetData<T>(SiteDataReference<T> dataReference)
+            where T : class, IGlogReferenceable
+        {
+            var dataType = typeof(T);
+            T data;
+
+            List<T> dataLookup;
+            if (dataType == typeof(CategoryData))
+            {
+                dataLookup = this.categories as List<T>;
+            }
+            else if (dataType == typeof(GameData))
+            {
+                dataLookup = this.games as List<T>;
+            }
+            else if (dataType == typeof(PlatformData))
+            {
+                dataLookup = this.platforms as List<T>;
+            }
+            else if (dataType == typeof(RatingData))
+            {
+                dataLookup = this.ratings as List<T>;
+            }
+            else if (dataType == typeof(TagData))
+            {
+                dataLookup = this.tags as List<T>;
+            }
+            else
+            {
+                throw new NotImplementedException($"Missing lookup for type {dataType.Name}");
+            }
+
+            // In this fake index, references are NEVER resolved,
+            // because there are no data IDs and resolved references mean nothing.
+            if (dataReference.GetIsResolved())
+            {
+                throw new ArgumentException($"The provided reference is resolved (ID {dataReference.GetResolvedReferenceId()}, which is not valid for FakeSiteDataIndex");
+            }
+
+            var referenceKey = dataReference.GetUnresolvedReferenceKey();
+
+            data = dataLookup.Where(v => v.MatchesReferenceableKey(referenceKey)).FirstOrDefault();
+            if (data == null)
+            {
+                // Invent the requested data.
+                if (dataType == typeof(CategoryData))
+                {
+                    var categoryData = new CategoryData() { Name = referenceKey };
+                    this.categories.Add(categoryData);
+                    data = categoryData as T;
+                }
+                else if (dataType == typeof(GameData))
+                {
+                    var gameData = new GameData() { Title = referenceKey };
+                    this.games.Add(gameData);
+                    data = gameData as T;
+                }
+                else if (dataType == typeof(PlatformData))
+                {
+                    var platformData = new PlatformData() { Abbreviation = referenceKey };
+                    this.platforms.Add(platformData);
+                    data = platformData as T;
+                }
+                else if (dataType == typeof(RatingData))
+                {
+                    var ratingData = new RatingData() { Name = referenceKey };
+                    this.ratings.Add(ratingData);
+                    data = ratingData as T;
+                }
+                else if (dataType == typeof(TagData))
+                {
+                    var tagData = new TagData(referenceKey);
+                    this.tags.Add(tagData);
+                    data = tagData as T;
+                }
+                else
+                {
+                    throw new NotImplementedException();
+                }
+            }
+
+            return data;
+        }
+
+        public List<CategoryData> GetCategories()
+        {
+            return this.categories.ToList();
+        }
+
+        public GameData GetGame(string gameTitle)
+        {
+            var game = this.games.Where(d => d.Title.Equals(gameTitle, StringComparison.Ordinal)).FirstOrDefault();
+            if (game == null)
+            {
+                throw new ArgumentException($"No game found for title {gameTitle}");
+            }
+
+            return game;
+        }
+
+        public List<GameData> GetGames()
+        {
+            return this.games.ToList();
+        }
+
+        public List<PageData> GetPages()
+        {
+            throw new NotImplementedException();
+        }
+
+        public PlatformData GetPlatform(string platformAbbreviation)
+        {
+            var platform = this.platforms.Where(d => d.Abbreviation.Equals(platformAbbreviation, StringComparison.Ordinal)).FirstOrDefault();
+            if (platform == null)
+            {
+                throw new ArgumentException($"No platform found for abbreviation {platformAbbreviation}");
+            }
+
+            return platform;
+        }
+
+        public List<PlatformData> GetPlatforms()
+        {
+            return this.platforms.ToList();
+        }
+
+        public PostData GetPostById(string postId)
+        {
+            throw new NotImplementedException();
+        }
+
+        public List<PostData> GetPosts()
+        {
+            throw new NotImplementedException();
+        }
+
+        public List<RatingData> GetRatings()
+        {
+            return this.ratings.ToList();
+        }
+
+        public string GetRawDataFile(string filePath)
+        {
+            throw new NotImplementedException();
+        }
+
+        public List<StaticFileData> GetStaticFiles()
+        {
+            throw new NotImplementedException();
+        }
+
+        public TagData GetTag(string tagName)
+        {
+            var tag = this.tags.Where(d => d.MatchesReferenceableKey(tagName)).FirstOrDefault();
+            if (tag == null)
+            {
+                throw new ArgumentException($"No tag found for name {tagName}");
+            }
+
+            return tag;
+        }
+
+        public List<TagData> GetTags()
+        {
+            return this.tags.ToList();
+        }
+
+        public void LoadContent(IIgdbCache igdbCache)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void ResolveReferences()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void RewriteSourceContent()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/GlogGenerator.Test/Data/FakeSiteDataIndex.cs
+++ b/GlogGenerator.Test/Data/FakeSiteDataIndex.cs
@@ -13,6 +13,12 @@ namespace GlogGenerator.Test
         private List<RatingData> ratings = new List<RatingData>();
         private List<TagData> tags = new List<TagData>();
 
+        public SiteDataReference<T> CreateReference<T>(string referenceKey)
+            where T : IGlogReferenceable
+        {
+            return new SiteDataReference<T>(referenceKey);
+        }
+
         public T GetData<T>(SiteDataReference<T> dataReference)
             where T : class, IGlogReferenceable
         {
@@ -180,7 +186,7 @@ namespace GlogGenerator.Test
             return this.tags.ToList();
         }
 
-        public void LoadContent(IIgdbCache igdbCache)
+        public void LoadContent(IIgdbCache igdbCache, Markdig.MarkdownPipeline markdownPipeline)
         {
             throw new NotImplementedException();
         }
@@ -190,7 +196,7 @@ namespace GlogGenerator.Test
             throw new NotImplementedException();
         }
 
-        public void RewriteSourceContent()
+        public void RewriteSourceContent(Markdig.MarkdownPipeline markdownPipeline)
         {
             throw new NotImplementedException();
         }

--- a/GlogGenerator.Test/Data/PostDataTests.cs
+++ b/GlogGenerator.Test/Data/PostDataTests.cs
@@ -1,8 +1,12 @@
+using System.Collections.Generic;
 using System.IO;
 using GlogGenerator.Data;
+using GlogGenerator.IgdbApi;
 using GlogGenerator.MarkdownExtensions;
 using Markdig;
+using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
 
 namespace GlogGenerator.Test.Data
 {
@@ -27,8 +31,9 @@ namespace GlogGenerator.Test.Data
             var testPostFileText = File.ReadAllText(testPostFilePath);
 
             var builder = new SiteBuilder();
+            var siteDataIndex = new FakeSiteDataIndex();
             var testPostData = PostData.MarkdownFromFilePath(builder.GetMarkdownPipeline(), testPostFilePath);
-            var testPostToString = testPostData.MdDoc.ToMarkdownString(builder.GetMarkdownPipeline());
+            var testPostToString = testPostData.ToMarkdownString(builder.GetMarkdownPipeline(), siteDataIndex);
 
             Assert.AreEqual(testPostFileText, testPostToString);
         }
@@ -40,10 +45,62 @@ namespace GlogGenerator.Test.Data
             var testPostFileText = File.ReadAllText(testPostFilePath);
 
             var builder = new SiteBuilder();
+            var siteDataIndex = new FakeSiteDataIndex();
             var testPostData = PostData.MarkdownFromFilePath(builder.GetMarkdownPipeline(), testPostFilePath);
-            var testPostToString = testPostData.MdDoc.ToMarkdownString(builder.GetMarkdownPipeline());
+            var testPostToString = testPostData.ToMarkdownString(builder.GetMarkdownPipeline(), siteDataIndex);
 
             Assert.AreEqual(testPostFileText, testPostToString);
+        }
+
+        [TestMethod]
+        public void TestToMarkdownAfterKeyChanges()
+        {
+            var logger = new TestLogger();
+
+            var testPostFileText = @"+++
+game = [ ""Middle-earth: Shadow of Mordor"" ]
++++
+<i>Oh yeah</i>, there's a new [Lord of the Rings game](game:The Lord of the Rings: Gollum) out!";
+
+            var testIgdbGameShadowOfMordor = new IgdbGame() { Id = 1, Name = "Middle-earth: Shadow of Mordor" };
+            var testIgdbGameGollum = new IgdbGame() { Id = 4, Name = "The Lord of the Rings: Gollum" };
+
+            var mockIgdbCache = Substitute.For<IIgdbCache>();
+            mockIgdbCache.GetAllGames().Returns(new List<IgdbGame>() { testIgdbGameShadowOfMordor, testIgdbGameGollum });
+            mockIgdbCache.GetAllPlatforms().Returns(new List<IgdbPlatform>());
+            mockIgdbCache.GetAllGameMetadata().Returns(new List<IgdbEntity>());
+
+            var builder = new SiteBuilder();
+            var testIndex = new SiteDataIndex(logger, builder, string.Empty);
+
+            testIndex.LoadContent(mockIgdbCache);
+
+            Assert.AreEqual(0, logger.GetLogs(LogLevel.Error).Count);
+            Assert.AreEqual(0, logger.GetLogs(LogLevel.Warning).Count);
+
+            var testPostData = PostData.MarkdownFromString(builder.GetMarkdownPipeline(), testPostFileText);
+            testPostData.ResolveReferences(testIndex);
+
+            testIgdbGameShadowOfMordor.Name = "Assassin's Creed Mordor";
+            testIgdbGameGollum.Name = "Goblin Mode";
+
+            testIndex.LoadContent(mockIgdbCache);
+
+            var testPostToString = testPostData.ToMarkdownString(builder.GetMarkdownPipeline(), testIndex);
+
+#if false
+            var expectedText = @"+++
+game = [ ""Assassin's Creed Mordor"" ]
++++
+<i>Oh yeah</i>, there's a new [Lord of the Rings game](game:Goblin Mode) out!";
+#else
+            var expectedText = @"+++
+game = [ ""Assassin's Creed Mordor"" ]
++++
+<i>Oh yeah</i>, there's a new [Lord of the Rings game](game:The Lord of the Rings: Gollum) out!";
+#endif
+
+            Assert.AreEqual(expectedText, testPostToString);
         }
     }
 }

--- a/GlogGenerator.Test/Data/SiteDataIndexTests.cs
+++ b/GlogGenerator.Test/Data/SiteDataIndexTests.cs
@@ -36,6 +36,13 @@ namespace GlogGenerator.Test.Data
 
             var testTag = testIndex.GetTag("Sonic the Hedgehog");
             Assert.AreEqual("Sonic The Hedgehog", testTag.Name);
+
+            var testReference = new SiteDataReference<TagData>("Sonic the Hedgehog");
+            var testReferenceResolved = testIndex.GetData(testReference);
+
+            Assert.IsTrue(testReference.GetIsResolved());
+            Assert.AreEqual("Sonic The Hedgehog", testReferenceResolved.Name);
+            Assert.AreEqual(testTag.GetDataId(), testReferenceResolved.GetDataId());
         }
 
         [TestMethod]

--- a/GlogGenerator.Test/Data/SiteDataIndexTests.cs
+++ b/GlogGenerator.Test/Data/SiteDataIndexTests.cs
@@ -26,10 +26,10 @@ namespace GlogGenerator.Test.Data
             mockIgdbCache.GetAllPlatforms().Returns(new List<IgdbPlatform>());
             mockIgdbCache.GetAllGameMetadata().Returns(testGameMetadata);
 
-            var mockSiteBuilder = Substitute.For<ISiteBuilder>();
-            var testIndex = new SiteDataIndex(logger, mockSiteBuilder, string.Empty);
+            var testIndex = new SiteDataIndex(logger, string.Empty);
+            var builder = new SiteBuilder(logger, new ConfigData(), testIndex);
 
-            testIndex.LoadContent(mockIgdbCache);
+            testIndex.LoadContent(mockIgdbCache, builder.GetMarkdownPipeline());
 
             Assert.AreEqual(0, logger.GetLogs(LogLevel.Error).Count);
             Assert.AreEqual(0, logger.GetLogs(LogLevel.Warning).Count);
@@ -57,10 +57,10 @@ namespace GlogGenerator.Test.Data
             mockIgdbCache.GetAllPlatforms().Returns(new List<IgdbPlatform>());
             mockIgdbCache.GetAllGameMetadata().Returns(new List<IgdbEntity>());
 
-            var mockSiteBuilder = Substitute.For<ISiteBuilder>();
-            var testIndex = new SiteDataIndex(logger, mockSiteBuilder, string.Empty);
+            var testIndex = new SiteDataIndex(logger, string.Empty);
+            var builder = new SiteBuilder(logger, new ConfigData(), testIndex);
 
-            testIndex.LoadContent(mockIgdbCache);
+            testIndex.LoadContent(mockIgdbCache, builder.GetMarkdownPipeline());
 
             Assert.AreEqual(0, logger.GetLogs(LogLevel.Error).Count);
             Assert.AreEqual(0, logger.GetLogs(LogLevel.Warning).Count);
@@ -73,7 +73,7 @@ namespace GlogGenerator.Test.Data
 
             testDataItem.Name = "Corrected Game Name";
 
-            testIndex.LoadContent(mockIgdbCache);
+            testIndex.LoadContent(mockIgdbCache, builder.GetMarkdownPipeline());
 
             var errors = logger.GetLogs(LogLevel.Error);
             Assert.AreEqual(1, errors.Count);
@@ -102,10 +102,10 @@ namespace GlogGenerator.Test.Data
             mockIgdbCache.GetAllPlatforms().Returns(new List<IgdbPlatform>() { testPlatformOld });
             mockIgdbCache.GetAllGameMetadata().Returns(new List<IgdbEntity>());
 
-            var mockSiteBuilder = Substitute.For<ISiteBuilder>();
-            var testIndex = new SiteDataIndex(logger, mockSiteBuilder, string.Empty);
+            var testIndex = new SiteDataIndex(logger, string.Empty);
+            var builder = new SiteBuilder(logger, new ConfigData(), testIndex);
 
-            testIndex.LoadContent(mockIgdbCache);
+            testIndex.LoadContent(mockIgdbCache, builder.GetMarkdownPipeline());
 
             Assert.AreEqual(0, logger.GetLogs(LogLevel.Error).Count);
             Assert.AreEqual(0, logger.GetLogs(LogLevel.Warning).Count);
@@ -114,7 +114,7 @@ namespace GlogGenerator.Test.Data
 
             mockIgdbCache.GetAllPlatforms().Returns(new List<IgdbPlatform>() { testPlatformNew });
 
-            testIndex.LoadContent(mockIgdbCache);
+            testIndex.LoadContent(mockIgdbCache, builder.GetMarkdownPipeline());
 
             var errors = logger.GetLogs(LogLevel.Error);
             Assert.AreEqual(1, errors.Count);
@@ -137,17 +137,17 @@ namespace GlogGenerator.Test.Data
             mockIgdbCache.GetAllPlatforms().Returns(new List<IgdbPlatform>() { testPlatformOld });
             mockIgdbCache.GetAllGameMetadata().Returns(new List<IgdbEntity>());
 
-            var mockSiteBuilder = Substitute.For<ISiteBuilder>();
-            var testIndex = new SiteDataIndex(logger, mockSiteBuilder, string.Empty);
+            var testIndex = new SiteDataIndex(logger, string.Empty);
+            var builder = new SiteBuilder(logger, new ConfigData(), testIndex);
 
-            testIndex.LoadContent(mockIgdbCache);
+            testIndex.LoadContent(mockIgdbCache, builder.GetMarkdownPipeline());
 
             Assert.AreEqual(0, logger.GetLogs(LogLevel.Error).Count);
             Assert.AreEqual(0, logger.GetLogs(LogLevel.Warning).Count);
 
             mockIgdbCache.GetAllPlatforms().Returns(new List<IgdbPlatform>());
 
-            testIndex.LoadContent(mockIgdbCache);
+            testIndex.LoadContent(mockIgdbCache, builder.GetMarkdownPipeline());
 
             var errors = logger.GetLogs(LogLevel.Error);
             Assert.AreEqual(1, errors.Count);
@@ -170,10 +170,10 @@ namespace GlogGenerator.Test.Data
             mockIgdbCache.GetAllPlatforms().Returns(new List<IgdbPlatform>() { testPlatformOld });
             mockIgdbCache.GetAllGameMetadata().Returns(new List<IgdbEntity>());
 
-            var mockSiteBuilder = Substitute.For<ISiteBuilder>();
-            var testIndex = new SiteDataIndex(logger, mockSiteBuilder, string.Empty);
+            var testIndex = new SiteDataIndex(logger, string.Empty);
+            var builder = new SiteBuilder(logger, new ConfigData(), testIndex);
 
-            testIndex.LoadContent(mockIgdbCache);
+            testIndex.LoadContent(mockIgdbCache, builder.GetMarkdownPipeline());
 
             Assert.AreEqual(0, logger.GetLogs(LogLevel.Error).Count);
             Assert.AreEqual(0, logger.GetLogs(LogLevel.Warning).Count);
@@ -182,7 +182,7 @@ namespace GlogGenerator.Test.Data
 
             mockIgdbCache.GetAllPlatforms().Returns(new List<IgdbPlatform>() { testPlatformNew });
 
-            testIndex.LoadContent(mockIgdbCache);
+            testIndex.LoadContent(mockIgdbCache, builder.GetMarkdownPipeline());
 
             Assert.AreEqual(0, logger.GetLogs(LogLevel.Error).Count);
 

--- a/GlogGenerator.Test/Data/SiteDataReferenceTests.cs
+++ b/GlogGenerator.Test/Data/SiteDataReferenceTests.cs
@@ -1,0 +1,44 @@
+using System;
+using GlogGenerator.Data;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+
+namespace GlogGenerator.Test.Data
+{
+    [TestClass]
+    public class SiteDataReferenceTests
+    {
+        [TestMethod]
+        public void TestNewUnresolvedReference()
+        {
+            var testReference = new SiteDataReference<TagData>("Test Tag");
+
+            Assert.IsFalse(testReference.GetIsResolved());
+        }
+
+        [TestMethod]
+        public void TestResolvedReference()
+        {
+            var testTag = new TagData("Test Tag");
+
+            var testReference = new SiteDataReference<TagData>("Test Tag");
+            testReference.SetData(testTag);
+
+            Assert.IsTrue(testReference.GetIsResolved());
+            Assert.IsTrue(string.IsNullOrEmpty(testReference.GetUnresolvedReferenceKey()));
+
+            Assert.AreEqual(testTag.GetDataId(), testReference.GetResolvedReferenceId());
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void TestResolveEmptyIdException()
+        {
+            var mockData = Substitute.For<IGlogReferenceable>();
+            mockData.GetDataId().Returns(string.Empty);
+
+            var testReference = new SiteDataReference<IGlogReferenceable>("Test Tag");
+            testReference.SetData(mockData);
+        }
+    }
+}

--- a/GlogGenerator.Test/MarkdownExtensions/GlogLinkTests.cs
+++ b/GlogGenerator.Test/MarkdownExtensions/GlogLinkTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using GlogGenerator.Data;
 using GlogGenerator.MarkdownExtensions;
 using Markdig;
@@ -50,6 +51,48 @@ namespace GlogGenerator.Test.MarkdownExtensions
                     throw new NotImplementedException();
                 }
             }
+
+            mockSiteDataIndex.CreateReference<GameData>(Arg.Any<string>()).Returns(args =>
+            {
+                var referenceKey = args.ArgAt<string>(0);
+                return new SiteDataReference<GameData>(referenceKey);
+            });
+
+            mockSiteDataIndex.CreateReference<PlatformData>(Arg.Any<string>()).Returns(args =>
+            {
+                var referenceKey = args.ArgAt<string>(0);
+                return new SiteDataReference<PlatformData>(referenceKey);
+            });
+
+            mockSiteDataIndex.CreateReference<TagData>(Arg.Any<string>()).Returns(args =>
+            {
+                var referenceKey = args.ArgAt<string>(0);
+                return new SiteDataReference<TagData>(referenceKey);
+            });
+
+            mockSiteDataIndex.GetData<GameData>(Arg.Any<SiteDataReference<GameData>>()).Returns(args =>
+            {
+                var dataReference = args.ArgAt<SiteDataReference<GameData>>(0);
+                var key = dataReference.GetUnresolvedReferenceKey();
+                var data = testGames.Where(g => g.MatchesReferenceableKey(key)).FirstOrDefault();
+                return data;
+            });
+
+            mockSiteDataIndex.GetData<PlatformData>(Arg.Any<SiteDataReference<PlatformData>>()).Returns(args =>
+            {
+                var dataReference = args.ArgAt<SiteDataReference<PlatformData>>(0);
+                var key = dataReference.GetUnresolvedReferenceKey();
+                var data = testPlatforms.Where(g => g.MatchesReferenceableKey(key)).FirstOrDefault();
+                return data;
+            });
+
+            mockSiteDataIndex.GetData<TagData>(Arg.Any<SiteDataReference<TagData>>()).Returns(args =>
+            {
+                var dataReference = args.ArgAt<SiteDataReference<TagData>>(0);
+                var key = dataReference.GetUnresolvedReferenceKey();
+                var data = testTags.Where(g => g.MatchesReferenceableKey(key)).FirstOrDefault();
+                return data;
+            });
 
             mockSiteDataIndex.GetGames().Returns(testGames);
             mockSiteDataIndex.GetPlatforms().Returns(testPlatforms);

--- a/GlogGenerator/Data/CategoryData.cs
+++ b/GlogGenerator/Data/CategoryData.cs
@@ -9,7 +9,7 @@ namespace GlogGenerator.Data
     {
         public string Name { get; set; } = string.Empty;
 
-        public List<PostData> LinkedPosts { get; set; } = new List<PostData>();
+        public List<string> LinkedPostIds { get; set; } = new List<string>();
 
         public string GetDataId()
         {

--- a/GlogGenerator/Data/CategoryData.cs
+++ b/GlogGenerator/Data/CategoryData.cs
@@ -28,12 +28,18 @@ namespace GlogGenerator.Data
 
         public string GetReferenceableKey()
         {
-            return UrlizedString.Urlize(this.Name);
+            return this.Name;
+        }
+
+        public bool MatchesReferenceableKey(string matchKey)
+        {
+            var thisKey = this.GetReferenceableKey();
+            return thisKey.Equals(matchKey, StringComparison.Ordinal);
         }
 
         public string GetPermalinkRelative()
         {
-            var urlized = UrlizedString.Urlize(this.Name);
+            var urlized = UrlizedString.Urlize(this.GetReferenceableKey());
             return $"category/{urlized}/";
         }
     }

--- a/GlogGenerator/Data/GameData.cs
+++ b/GlogGenerator/Data/GameData.cs
@@ -15,7 +15,7 @@ namespace GlogGenerator.Data
 
         public List<string> Tags { get; set; } = new List<string>();
 
-        public List<PostData> LinkedPosts { get; set; } = new List<PostData>();
+        public List<string> LinkedPostIds { get; set; } = new List<string>();
 
         private string dataId;
         private string referenceableKey;

--- a/GlogGenerator/Data/GameData.cs
+++ b/GlogGenerator/Data/GameData.cs
@@ -32,12 +32,19 @@ namespace GlogGenerator.Data
                 return this.referenceableKey;
             }
 
-            return UrlizedString.Urlize(this.Title);
+            return this.Title;
+        }
+
+        public bool MatchesReferenceableKey(string matchKey)
+        {
+            var thisKey = this.GetReferenceableKey();
+            return thisKey.Equals(matchKey, StringComparison.Ordinal);
         }
 
         public string GetPermalinkRelative()
         {
-            return $"game/{this.GetReferenceableKey()}/";
+            var urlized = UrlizedString.Urlize(this.GetReferenceableKey());
+            return $"game/{urlized}/";
         }
 
         public static GameData FromIgdbGame(IIgdbCache igdbCache, IgdbGame igdbGame)

--- a/GlogGenerator/Data/IGlogMultiKeyReferenceable.cs
+++ b/GlogGenerator/Data/IGlogMultiKeyReferenceable.cs
@@ -1,7 +1,11 @@
-﻿namespace GlogGenerator.Data
+﻿using System.Collections.Generic;
+
+namespace GlogGenerator.Data
 {
     public interface IGlogMultiKeyReferenceable : IGlogReferenceable
     {
+        public bool ShouldMergeWithReferenceableKey(string checkKey);
+
         public void MergeReferenceableKey(string mergeKey);
     }
 }

--- a/GlogGenerator/Data/IGlogReferenceable.cs
+++ b/GlogGenerator/Data/IGlogReferenceable.cs
@@ -6,6 +6,8 @@
 
         public string GetReferenceableKey();
 
+        public bool MatchesReferenceableKey(string matchKey);
+
         public string GetPermalinkRelative();
     }
 }

--- a/GlogGenerator/Data/ISiteDataIndex.cs
+++ b/GlogGenerator/Data/ISiteDataIndex.cs
@@ -19,6 +19,8 @@ namespace GlogGenerator.Data
 
         public List<PlatformData> GetPlatforms();
 
+        public PostData GetPostById(string postId);
+
         public List<PostData> GetPosts();
 
         public List<RatingData> GetRatings();

--- a/GlogGenerator/Data/ISiteDataIndex.cs
+++ b/GlogGenerator/Data/ISiteDataIndex.cs
@@ -4,6 +4,9 @@ namespace GlogGenerator.Data
 {
     public interface ISiteDataIndex
     {
+        public SiteDataReference<T> CreateReference<T>(string referenceKey)
+            where T : IGlogReferenceable;
+
         public T GetData<T>(SiteDataReference<T> dataReference)
             where T : class, IGlogReferenceable;
 
@@ -33,10 +36,10 @@ namespace GlogGenerator.Data
 
         public List<TagData> GetTags();
 
-        public void LoadContent(IIgdbCache igdbCache);
+        public void LoadContent(IIgdbCache igdbCache, Markdig.MarkdownPipeline markdownPipeline);
 
         public void ResolveReferences();
 
-        public void RewriteSourceContent();
+        public void RewriteSourceContent(Markdig.MarkdownPipeline markdownPipeline);
     }
 }

--- a/GlogGenerator/Data/ISiteDataIndex.cs
+++ b/GlogGenerator/Data/ISiteDataIndex.cs
@@ -4,6 +4,9 @@ namespace GlogGenerator.Data
 {
     public interface ISiteDataIndex
     {
+        public T GetData<T>(SiteDataReference<T> dataReference)
+            where T : IGlogReferenceable;
+
         public List<CategoryData> GetCategories();
 
         public GameData GetGame(string gameTitle);

--- a/GlogGenerator/Data/ISiteDataIndex.cs
+++ b/GlogGenerator/Data/ISiteDataIndex.cs
@@ -5,7 +5,7 @@ namespace GlogGenerator.Data
     public interface ISiteDataIndex
     {
         public T GetData<T>(SiteDataReference<T> dataReference)
-            where T : IGlogReferenceable;
+            where T : class, IGlogReferenceable;
 
         public List<CategoryData> GetCategories();
 
@@ -34,6 +34,8 @@ namespace GlogGenerator.Data
         public List<TagData> GetTags();
 
         public void LoadContent(IIgdbCache igdbCache);
+
+        public void ResolveReferences();
 
         public void RewriteSourceContent();
     }

--- a/GlogGenerator/Data/ISiteDataReference.cs
+++ b/GlogGenerator/Data/ISiteDataReference.cs
@@ -1,0 +1,13 @@
+namespace GlogGenerator.Data
+{
+    public interface ISiteDataReference
+    {
+        public bool GetIsResolved();
+
+        public string GetUnresolvedReferenceKey();
+
+        public string GetResolvedReferenceId();
+
+        public void SetData(IGlogReferenceable data);
+    }
+}

--- a/GlogGenerator/Data/PageData.cs
+++ b/GlogGenerator/Data/PageData.cs
@@ -13,33 +13,7 @@ namespace GlogGenerator.Data
 
         public string SourceFilePath { get; private set; } = string.Empty;
 
-        public string PermalinkRelative
-        {
-            get
-            {
-                var frontMatter = this.GetFrontMatter();
-                if (frontMatter != null && frontMatter.TryGetNode("permalink", out var frontMatterPermalink))
-                {
-                    var permalinkString = frontMatterPermalink.ToString();
-                    if (!string.IsNullOrEmpty(permalinkString))
-                    {
-                        if (permalinkString.StartsWith('/'))
-                        {
-                            permalinkString = permalinkString.Substring(1);
-                        }
-
-                        if (!permalinkString.EndsWith('/'))
-                        {
-                            permalinkString += '/';
-                        }
-
-                        return permalinkString;
-                    }
-                }
-
-                return string.Empty;
-            }
-        }
+        public string PermalinkRelative { get { return this.permalinkRelative; } }
 
         public void RewriteSourceFile(MarkdownPipeline mdPipeline)
         {
@@ -56,16 +30,7 @@ namespace GlogGenerator.Data
 
         public MarkdownDocument MdDoc { get; private set; }
 
-        private Tommy.TomlTable GetFrontMatter()
-        {
-            var frontMatterBlock = this.MdDoc.Descendants<TomlFrontMatterBlock>().FirstOrDefault();
-            if (frontMatterBlock != null)
-            {
-                return frontMatterBlock.GetModel();
-            }
-
-            return null;
-        }
+        private string permalinkRelative = null;
 
         public static PageData MarkdownFromFilePath(MarkdownPipeline mdPipeline, string filePath)
         {
@@ -75,6 +40,31 @@ namespace GlogGenerator.Data
             page.SourceFilePath = filePath;
 
             page.MdDoc = Markdown.Parse(text, mdPipeline);
+
+            var frontMatterBlock = page.MdDoc.Descendants<TomlFrontMatterBlock>().FirstOrDefault();
+            if (frontMatterBlock != null)
+            {
+                var frontMatter = frontMatterBlock.GetModel();
+            
+                if (frontMatter.TryGetNode("permalink", out var frontMatterPermalink))
+                {
+                    var permalinkString = frontMatterPermalink.ToString();
+                    if (!string.IsNullOrEmpty(permalinkString))
+                    {
+                        if (permalinkString.StartsWith('/'))
+                        {
+                            permalinkString = permalinkString.Substring(1);
+                        }
+
+                        if (!permalinkString.EndsWith('/'))
+                        {
+                            permalinkString += '/';
+                        }
+
+                        page.permalinkRelative = permalinkString;
+                    }
+                }
+            }
 
             return page;
         }

--- a/GlogGenerator/Data/PlatformData.cs
+++ b/GlogGenerator/Data/PlatformData.cs
@@ -29,12 +29,19 @@ namespace GlogGenerator.Data
                 return this.referenceableKey;
             }
 
-            return UrlizedString.Urlize(this.Abbreviation);
+            return this.Abbreviation;
+        }
+
+        public bool MatchesReferenceableKey(string matchKey)
+        {
+            var thisKey = this.GetReferenceableKey();
+            return thisKey.Equals(matchKey, StringComparison.Ordinal);
         }
 
         public string GetPermalinkRelative()
         {
-            return $"platform/{this.GetReferenceableKey()}/";
+            var urlized = UrlizedString.Urlize(this.GetReferenceableKey());
+            return $"platform/{urlized}/";
         }
 
         public static PlatformData FromIgdbPlatform(IIgdbCache igdbCache, IgdbPlatform igdbPlatform)

--- a/GlogGenerator/Data/PlatformData.cs
+++ b/GlogGenerator/Data/PlatformData.cs
@@ -12,7 +12,7 @@ namespace GlogGenerator.Data
 
         public string IgdbUrl { get; set; }
 
-        public List<PostData> LinkedPosts { get; set; } = new List<PostData>();
+        public List<string> LinkedPostIds { get; set; } = new List<string>();
 
         private string dataId;
         private string referenceableKey;

--- a/GlogGenerator/Data/PostData.cs
+++ b/GlogGenerator/Data/PostData.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Text;
 using GlogGenerator.MarkdownExtensions;
 using Markdig;
@@ -53,6 +54,21 @@ namespace GlogGenerator.Data
         public List<SiteDataReference<PlatformData>> Platforms { get { return this.platforms; } }
 
         public List<SiteDataReference<RatingData>> Ratings { get { return this.ratings; } }
+
+        public string GetPostId()
+        {
+            using (var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256))
+            {
+                var typeBytes = Encoding.UTF8.GetBytes(nameof(PostData));
+                hash.AppendData(typeBytes);
+
+                var permalinkRelativeBytes = Encoding.UTF8.GetBytes(this.PermalinkRelative);
+                hash.AppendData(permalinkRelativeBytes);
+
+                var idBytes = hash.GetCurrentHash();
+                return Convert.ToHexString(idBytes);
+            }
+        }
 
         public void RewriteSourceFile(MarkdownPipeline mdPipeline)
         {

--- a/GlogGenerator/Data/PostData.cs
+++ b/GlogGenerator/Data/PostData.cs
@@ -70,29 +70,6 @@ namespace GlogGenerator.Data
             }
         }
 
-        public void ResolveReferences(ISiteDataIndex siteDataIndex)
-        {
-            foreach (var categoryReference in this.categories.Select(t => t.Item2))
-            {
-                _ = siteDataIndex.GetData(categoryReference);
-            }
-
-            foreach (var gameReference in this.games.Select(t => t.Item2))
-            {
-                _ = siteDataIndex.GetData(gameReference);
-            }
-
-            foreach (var platformReference in this.platforms.Select(t => t.Item2))
-            {
-                _ = siteDataIndex.GetData(platformReference);
-            }
-
-            foreach (var ratingReference in this.ratings.Select(t => t.Item2))
-            {
-                _ = siteDataIndex.GetData(ratingReference);
-            }
-        }
-
         public string ToMarkdownString(MarkdownPipeline mdPipeline, ISiteDataIndex siteDataIndex)
         {
             // Rewrite all referenceable data keys in the TOML front matter,
@@ -153,16 +130,16 @@ namespace GlogGenerator.Data
         private List<Tuple<Tommy.TomlString, SiteDataReference<PlatformData>>> platforms = new List<Tuple<Tommy.TomlString, SiteDataReference<PlatformData>>>();
         private List<Tuple<Tommy.TomlString, SiteDataReference<RatingData>>> ratings = new List<Tuple<Tommy.TomlString, SiteDataReference<RatingData>>>();
 
-        public static PostData MarkdownFromFilePath(MarkdownPipeline mdPipeline, string filePath)
+        public static PostData MarkdownFromFilePath(MarkdownPipeline mdPipeline, string filePath, ISiteDataIndex siteDataIndex)
         {
             var fileContent = File.ReadAllText(filePath);
-            var post = MarkdownFromString(mdPipeline, fileContent);
+            var post = MarkdownFromString(mdPipeline, fileContent, siteDataIndex);
             post.SourceFilePath = filePath;
 
             return post;
         }
 
-        public static PostData MarkdownFromString(MarkdownPipeline mdPipeline, string fileContent)
+        public static PostData MarkdownFromString(MarkdownPipeline mdPipeline, string fileContent, ISiteDataIndex siteDataIndex)
         {
             var post = new PostData();
 
@@ -201,7 +178,7 @@ namespace GlogGenerator.Data
                 {
                     foreach (var categoryName in frontMatterCategories)
                     {
-                        var categoryReference = new SiteDataReference<CategoryData>(categoryName.ToString());
+                        var categoryReference = siteDataIndex.CreateReference<CategoryData>(categoryName.ToString());
 
                         var frontMatterReference = Tuple.Create(categoryName as Tommy.TomlString, categoryReference);
                         post.categories.Add(frontMatterReference);
@@ -212,7 +189,7 @@ namespace GlogGenerator.Data
                 {
                     foreach (var gameTitle in frontMatterGames)
                     {
-                        var gameReference = new SiteDataReference<GameData>(gameTitle.ToString());
+                        var gameReference = siteDataIndex.CreateReference<GameData>(gameTitle.ToString());
 
                         var frontMatterReference = Tuple.Create(gameTitle as Tommy.TomlString, gameReference);
                         post.games.Add(frontMatterReference);
@@ -223,7 +200,7 @@ namespace GlogGenerator.Data
                 {
                     foreach (var platformAbbreviation in frontMatterPlatforms)
                     {
-                        var platformReference = new SiteDataReference<PlatformData>(platformAbbreviation.ToString());
+                        var platformReference = siteDataIndex.CreateReference<PlatformData>(platformAbbreviation.ToString());
 
                         var frontMatterReference = Tuple.Create(platformAbbreviation as Tommy.TomlString, platformReference);
                         post.platforms.Add(frontMatterReference);
@@ -234,7 +211,7 @@ namespace GlogGenerator.Data
                 {
                     foreach (var ratingName in frontMatterRatings)
                     {
-                        var ratingReference = new SiteDataReference<RatingData>(ratingName.ToString());
+                        var ratingReference = siteDataIndex.CreateReference<RatingData>(ratingName.ToString());
 
                         var frontMatterReference = Tuple.Create(ratingName as Tommy.TomlString, ratingReference);
                         post.ratings.Add(frontMatterReference);

--- a/GlogGenerator/Data/RatingData.cs
+++ b/GlogGenerator/Data/RatingData.cs
@@ -9,7 +9,7 @@ namespace GlogGenerator.Data
     {
         public string Name { get; set; } = string.Empty;
 
-        public List<PostData> LinkedPosts { get; set; } = new List<PostData>();
+        public List<string> LinkedPostIds { get; set; } = new List<string>();
 
         public string GetDataId()
         {

--- a/GlogGenerator/Data/RatingData.cs
+++ b/GlogGenerator/Data/RatingData.cs
@@ -28,7 +28,13 @@ namespace GlogGenerator.Data
 
         public string GetReferenceableKey()
         {
-            return UrlizedString.Urlize(this.Name);
+            return this.Name;
+        }
+
+        public bool MatchesReferenceableKey(string matchKey)
+        {
+            var thisKey = this.GetReferenceableKey();
+            return thisKey.Equals(matchKey, StringComparison.Ordinal);
         }
 
         public string GetPermalinkRelative()

--- a/GlogGenerator/Data/SiteDataIndex.cs
+++ b/GlogGenerator/Data/SiteDataIndex.cs
@@ -37,38 +37,6 @@ namespace GlogGenerator.Data
             this.inputFilesBasePath = inputFilesBasePath;
         }
 
-        private CategoryData AddCategoryIfMissing(string categoryName)
-        {
-            var category = this.categories.Values.Where(d => d.Name.Equals(categoryName, StringComparison.Ordinal)).FirstOrDefault();
-            if (category == null)
-            {
-                category = new CategoryData()
-                {
-                    Name = categoryName,
-                };
-
-                this.categories[category.GetDataId()] = category;
-            }
-
-            return category;
-        }
-
-        private RatingData AddRatingIfMissing(string ratingName)
-        {
-            var rating = this.ratings.Values.Where(d => d.Name.Equals(ratingName, StringComparison.Ordinal)).FirstOrDefault();
-            if (rating == null)
-            {
-                rating = new RatingData()
-                {
-                    Name = ratingName,
-                };
-
-                this.ratings[rating.GetDataId()] = rating;
-            }
-
-            return rating;
-        }
-
         public SiteDataReference<T> CreateReference<T>(string referenceKey)
             where T : IGlogReferenceable
         {

--- a/GlogGenerator/Data/SiteDataIndex.cs
+++ b/GlogGenerator/Data/SiteDataIndex.cs
@@ -67,7 +67,7 @@ namespace GlogGenerator.Data
         }
 
         public T GetData<T>(SiteDataReference<T> dataReference)
-            where T : IGlogReferenceable
+            where T : class, IGlogReferenceable
         {
             var dataType = typeof(T);
             T data;
@@ -438,6 +438,14 @@ namespace GlogGenerator.Data
             this.CheckUpdatedReferenceableDataForConflict(oldTags.Values, this.tags.Values);
         }
 
+        public void ResolveReferences()
+        {
+            foreach (var post in this.posts.Values)
+            {
+                post.ResolveReferences(this);
+            }
+        }
+
         public void RewriteSourceContent()
         {
             foreach (var page in this.pages)
@@ -447,7 +455,7 @@ namespace GlogGenerator.Data
 
             foreach (var post in this.posts.Values)
             {
-                post.RewriteSourceFile(this.siteBuilder.GetMarkdownPipeline());
+                post.RewriteSourceFile(this.siteBuilder.GetMarkdownPipeline(), this);
             }
         }
 

--- a/GlogGenerator/Data/SiteDataReference.cs
+++ b/GlogGenerator/Data/SiteDataReference.cs
@@ -1,0 +1,47 @@
+using System;
+
+namespace GlogGenerator.Data
+{
+    public class SiteDataReference<T>
+        where T : IGlogReferenceable
+    {
+        private string unresolvedReferenceKey = null;
+        private string resolvedReferenceId = null;
+
+        public SiteDataReference(string referenceKey)
+        {
+            this.unresolvedReferenceKey = referenceKey;
+        }
+
+        public SiteDataReference(T data)
+        {
+            this.resolvedReferenceId = data.GetDataId();
+        }
+
+        public bool GetIsResolved()
+        {
+            return !string.IsNullOrEmpty(resolvedReferenceId);
+        }
+
+        public string GetUnresolvedReferenceKey()
+        {
+            return this.unresolvedReferenceKey;
+        }
+
+        public string GetResolvedReferenceId()
+        {
+            return this.resolvedReferenceId;
+        }
+
+        public void SetData(T data)
+        {
+            this.resolvedReferenceId = data.GetDataId();
+            if (string.IsNullOrEmpty(this.resolvedReferenceId))
+            {
+                throw new ArgumentException("Data is missing an ID");
+            }
+            
+            this.unresolvedReferenceKey = null;
+        }
+    }
+}

--- a/GlogGenerator/Data/SiteDataReference.cs
+++ b/GlogGenerator/Data/SiteDataReference.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace GlogGenerator.Data
 {
-    public class SiteDataReference<T>
+    public class SiteDataReference<T> : ISiteDataReference
         where T : IGlogReferenceable
     {
         private string unresolvedReferenceKey = null;
@@ -11,11 +11,6 @@ namespace GlogGenerator.Data
         public SiteDataReference(string referenceKey)
         {
             this.unresolvedReferenceKey = referenceKey;
-        }
-
-        public SiteDataReference(T data)
-        {
-            this.resolvedReferenceId = data.GetDataId();
         }
 
         public bool GetIsResolved()
@@ -33,7 +28,7 @@ namespace GlogGenerator.Data
             return this.resolvedReferenceId;
         }
 
-        public void SetData(T data)
+        public void SetData(IGlogReferenceable data)
         {
             this.resolvedReferenceId = data.GetDataId();
             if (string.IsNullOrEmpty(this.resolvedReferenceId))

--- a/GlogGenerator/Data/TagData.cs
+++ b/GlogGenerator/Data/TagData.cs
@@ -50,8 +50,9 @@ namespace GlogGenerator.Data
                 var typeBytes = Encoding.UTF8.GetBytes(nameof(TagData));
                 hash.AppendData(typeBytes);
 
-                var nameBytes = Encoding.UTF8.GetBytes(this.Name);
-                hash.AppendData(nameBytes);
+                var nameUrlized = UrlizedString.Urlize(this.Name);
+                var nameUrlizedBytes = Encoding.UTF8.GetBytes(nameUrlized);
+                hash.AppendData(nameUrlizedBytes);
 
                 var idBytes = hash.GetCurrentHash();
                 return Convert.ToHexString(idBytes);

--- a/GlogGenerator/Data/TagData.cs
+++ b/GlogGenerator/Data/TagData.cs
@@ -16,7 +16,7 @@ namespace GlogGenerator.Data
             }
         }
 
-        public List<PostData> LinkedPosts { get; set; } = new List<PostData>();
+        public List<string> LinkedPostIds { get; set; } = new List<string>();
 
         private SortedSet<string> referenceableKeys = new SortedSet<string>(StringComparer.Ordinal);
 

--- a/GlogGenerator/Data/TagData.cs
+++ b/GlogGenerator/Data/TagData.cs
@@ -60,7 +60,7 @@ namespace GlogGenerator.Data
 
         public string GetReferenceableKey()
         {
-            return UrlizedString.Urlize(this.Name);
+            return this.Name;
         }
 
         public string GetPermalinkRelative()

--- a/GlogGenerator/Data/TagData.cs
+++ b/GlogGenerator/Data/TagData.cs
@@ -25,6 +25,19 @@ namespace GlogGenerator.Data
             this.referenceableKeys.Add(gameMetadataName);
         }
 
+        public bool MatchesReferenceableKey(string matchKey)
+        {
+            return this.referenceableKeys.Contains(matchKey);
+        }
+
+        public bool ShouldMergeWithReferenceableKey(string checkKey)
+        {
+            var thisKeyUrlized = new UrlizedString(this.Name);
+            var checkKeyUrlized = new UrlizedString(checkKey);
+
+            return thisKeyUrlized.Equals(checkKeyUrlized);
+        }
+
         public void MergeReferenceableKey(string mergeKey)
         {
             this.referenceableKeys.Add(mergeKey);
@@ -52,7 +65,7 @@ namespace GlogGenerator.Data
 
         public string GetPermalinkRelative()
         {
-            var urlized = UrlizedString.Urlize(this.Name);
+            var urlized = UrlizedString.Urlize(this.GetReferenceableKey());
             return $"tag/{urlized}/";
         }
     }

--- a/GlogGenerator/ISiteBuilder.cs
+++ b/GlogGenerator/ISiteBuilder.cs
@@ -16,6 +16,8 @@ namespace GlogGenerator
 
         public void UpdateDataIndex();
 
+        public void ResolveDataReferences();
+
         public List<PageData> GetPages();
 
         public List<PostData> GetPosts();

--- a/GlogGenerator/IgdbApi/IgdbEntity.cs
+++ b/GlogGenerator/IgdbApi/IgdbEntity.cs
@@ -99,7 +99,7 @@ namespace GlogGenerator.IgdbApi
 
         public string GetReferenceableKey()
         {
-            return UrlizedString.Urlize(this.GetReferenceableValue());
+            return this.GetReferenceableValue();
         }
     }
 

--- a/GlogGenerator/MarkdownExtensions/GlogAutoLinkInlineParser.cs
+++ b/GlogGenerator/MarkdownExtensions/GlogAutoLinkInlineParser.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using GlogGenerator.Data;
 using Markdig.Helpers;
 using Markdig.Parsers;
 using Markdig.Parsers.Inlines;
@@ -11,10 +12,14 @@ namespace GlogGenerator.MarkdownExtensions
 {
     public class GlogAutoLinkInlineParser : AutolinkInlineParser
     {
+        private readonly ISiteDataIndex siteDataIndex;
+
         private Dictionary<string, string> linkMatchTypes;
 
-        public GlogAutoLinkInlineParser() : base()
+        public GlogAutoLinkInlineParser(ISiteDataIndex siteDataIndex) : base()
         {
+            this.siteDataIndex = siteDataIndex;
+
             this.linkMatchTypes = new Dictionary<string, string>();
             foreach (var linkHandler in GlogLinkHandlers.LinkMatchHandlers)
             {
@@ -65,14 +70,12 @@ namespace GlogGenerator.MarkdownExtensions
                             }
                         }
 
-                        var referenceType = linkMatchHandler.Value;
+                        var referenceTypeName = linkMatchHandler.Value;
                         var referenceKey = slice.Text.Substring(slice.Start, referenceEndPos - slice.Start);
 
-                        var glogLinkInline = new GlogLinkInline()
+                        var glogLinkInline = new GlogLinkInline(referenceTypeName, referenceKey, this.siteDataIndex)
                         {
                             IsAutoLink = true,
-                            ReferenceType = referenceType,
-                            ReferenceKey = referenceKey,
                             // TODO?: would filling in Span, Row, and Column accomplish anything?
                         };
                         glogLinkInline.AppendChild(new LiteralInline(referenceKey));

--- a/GlogGenerator/MarkdownExtensions/GlogLinkHtmlRenderer.cs
+++ b/GlogGenerator/MarkdownExtensions/GlogLinkHtmlRenderer.cs
@@ -25,10 +25,10 @@ namespace GlogGenerator.MarkdownExtensions
 
         protected override void Write(HtmlRenderer renderer, GlogLinkInline obj)
         {
-            var linkHandler = GlogLinkHandlers.LinkMatchHandlers[obj.ReferenceType];
+            var linkHandler = GlogLinkHandlers.LinkMatchHandlers[obj.ReferenceTypeName];
 
             var link = obj as LinkInline;
-            link.Url = linkHandler(this.siteDataIndex, this.siteState, obj.ReferenceKey);
+            link.Url = linkHandler(this.siteDataIndex, this.siteState, obj.GetReferenceKey(this.siteDataIndex));
 
             this.linkInlineRenderer.Write(renderer, link);
         }

--- a/GlogGenerator/MarkdownExtensions/GlogLinkInline.cs
+++ b/GlogGenerator/MarkdownExtensions/GlogLinkInline.cs
@@ -1,11 +1,85 @@
-﻿using Markdig.Syntax.Inlines;
+﻿using System;
+using GlogGenerator.Data;
+using Markdig.Syntax.Inlines;
 
 namespace GlogGenerator.MarkdownExtensions
 {
     public class GlogLinkInline : LinkInline
     {
-        public string ReferenceType { get; set; }
+        public string ReferenceTypeName { get; private set; }
 
-        public string ReferenceKey { get; set; }
+        public ISiteDataReference DataReference { get; private set; }
+
+        public GlogLinkInline(string referenceTypeName, string referenceKey, ISiteDataIndex siteDataIndex)
+        {
+            this.ReferenceTypeName = referenceTypeName;
+            switch (referenceTypeName)
+            {
+                case "category":
+                    this.DataReference = siteDataIndex.CreateReference<CategoryData>(referenceKey) as ISiteDataReference;
+                    break;
+
+                case "game":
+                    this.DataReference = siteDataIndex.CreateReference<GameData>(referenceKey) as ISiteDataReference;
+                    break;
+
+                case "platform":
+                    this.DataReference = siteDataIndex.CreateReference<PlatformData>(referenceKey) as ISiteDataReference;
+                    break;
+
+                case "rating":
+                    this.DataReference = siteDataIndex.CreateReference<RatingData>(referenceKey) as ISiteDataReference;
+                    break;
+
+                case "tag":
+                    this.DataReference = siteDataIndex.CreateReference<TagData>(referenceKey) as ISiteDataReference;
+                    break;
+
+                default:
+                    throw new NotImplementedException();
+            }
+        }
+
+        public string GetReferenceKey(ISiteDataIndex siteDataIndex)
+        {
+            IGlogReferenceable data;
+            switch (this.ReferenceTypeName)
+            {
+                case "category":
+                    var categoryReference = this.DataReference as SiteDataReference<CategoryData>;
+                    data = siteDataIndex.GetData<CategoryData>(categoryReference);
+                    break;
+
+                case "game":
+                    var gameReference = this.DataReference as SiteDataReference<GameData>;
+                    data = siteDataIndex.GetData<GameData>(gameReference);
+                    break;
+
+                case "platform":
+                    var platformReference = this.DataReference as SiteDataReference<PlatformData>;
+                    data = siteDataIndex.GetData<PlatformData>(platformReference);
+                    break;
+
+                case "rating":
+                    var ratingReference = this.DataReference as SiteDataReference<RatingData>;
+                    data = siteDataIndex.GetData<RatingData>(ratingReference);
+                    break;
+
+                case "tag":
+                    var tagReference = this.DataReference as SiteDataReference<TagData>;
+                    data = siteDataIndex.GetData<TagData>(tagReference);
+                    break;
+
+                default:
+                    throw new NotImplementedException();
+            }
+
+            if (data == null)
+            {
+                throw new ArgumentException($"No {this.ReferenceTypeName} found with key {this.DataReference.GetUnresolvedReferenceKey()}");
+            }
+
+            return data.GetReferenceableKey();
+        }
     }
 }

--- a/GlogGenerator/MarkdownExtensions/GlogLinkInlineParser.cs
+++ b/GlogGenerator/MarkdownExtensions/GlogLinkInlineParser.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using GlogGenerator.Data;
 using Markdig.Helpers;
 using Markdig.Parsers;
 using Markdig.Parsers.Inlines;
@@ -10,10 +11,14 @@ namespace GlogGenerator.MarkdownExtensions
 {
     public class GlogLinkInlineParser : LinkInlineParser
     {
+        private readonly ISiteDataIndex siteDataIndex;
+
         private Dictionary<string, string> linkMatchTypes;
 
-        public GlogLinkInlineParser() : base()
+        public GlogLinkInlineParser(ISiteDataIndex siteDataIndex) : base()
         {
+            this.siteDataIndex = siteDataIndex;
+
             this.linkMatchTypes = new Dictionary<string, string>();
             foreach (var linkHandler in GlogLinkHandlers.LinkMatchHandlers)
             {
@@ -68,13 +73,11 @@ namespace GlogGenerator.MarkdownExtensions
                             }
                         }
 
-                        var referenceType = linkMatchHandler.Value;
+                        var referenceTypeName = linkMatchHandler.Value;
                         var referenceKey = slice.Text.Substring(slice.Start, referenceEndPos - slice.Start);
 
-                        var glogLinkInline = new GlogLinkInline()
+                        var glogLinkInline = new GlogLinkInline(referenceTypeName, referenceKey, this.siteDataIndex)
                         {
-                            ReferenceType = referenceType,
-                            ReferenceKey = referenceKey,
                             // TODO?: would filling in Span, Row, and Column accomplish anything?
                         };
 

--- a/GlogGenerator/MarkdownExtensions/GlogLinkNormalizeRenderer.cs
+++ b/GlogGenerator/MarkdownExtensions/GlogLinkNormalizeRenderer.cs
@@ -1,21 +1,29 @@
-﻿using Markdig.Renderers;
+﻿using System.Text;
+using GlogGenerator.Data;
+using Markdig.Renderers;
 using Markdig.Renderers.Normalize;
 using Markdig.Syntax.Inlines;
-using System.Text;
 
 namespace GlogGenerator.MarkdownExtensions
 {
     public class GlogLinkNormalizeRenderer : NormalizeObjectRenderer<GlogLinkInline>
     {
+        private readonly ISiteDataIndex siteDataIndex;
+
+        public GlogLinkNormalizeRenderer(ISiteDataIndex siteDataIndex) : base()
+        {
+            this.siteDataIndex = siteDataIndex;
+        }
+
         protected override void Write(NormalizeRenderer renderer, GlogLinkInline obj)
         {
             var stringBuilder = new StringBuilder();
             if (obj.IsAutoLink)
             {
                 stringBuilder.Append('<');
-                stringBuilder.Append(obj.ReferenceType);
+                stringBuilder.Append(obj.ReferenceTypeName);
                 stringBuilder.Append(':');
-                stringBuilder.Append(obj.ReferenceKey);
+                stringBuilder.Append(obj.GetReferenceKey(this.siteDataIndex));
                 stringBuilder.Append('>');
             }
             else
@@ -24,9 +32,9 @@ namespace GlogGenerator.MarkdownExtensions
                 renderer.WriteChildren(obj);
 
                 stringBuilder.Append("](");
-                stringBuilder.Append(obj.ReferenceType);
+                stringBuilder.Append(obj.ReferenceTypeName);
                 stringBuilder.Append(':');
-                stringBuilder.Append(obj.ReferenceKey);
+                stringBuilder.Append(obj.GetReferenceKey(this.siteDataIndex));
                 stringBuilder.Append(')');
             }
 

--- a/GlogGenerator/MarkdownExtensions/GlogLinkRoundtripRenderer.cs
+++ b/GlogGenerator/MarkdownExtensions/GlogLinkRoundtripRenderer.cs
@@ -1,21 +1,29 @@
-﻿using Markdig.Renderers;
+﻿using System.Text;
+using GlogGenerator.Data;
+using Markdig.Renderers;
 using Markdig.Renderers.Roundtrip;
 using Markdig.Syntax.Inlines;
-using System.Text;
 
 namespace GlogGenerator.MarkdownExtensions
 {
     public class GlogLinkRoundtripRenderer : RoundtripObjectRenderer<GlogLinkInline>
     {
+        private readonly ISiteDataIndex siteDataIndex;
+
+        public GlogLinkRoundtripRenderer(ISiteDataIndex siteDataIndex) : base()
+        {
+            this.siteDataIndex = siteDataIndex;
+        }
+
         protected override void Write(RoundtripRenderer renderer, GlogLinkInline obj)
         {
             var stringBuilder = new StringBuilder();
             if (obj.IsAutoLink)
             {
                 stringBuilder.Append('<');
-                stringBuilder.Append(obj.ReferenceType);
+                stringBuilder.Append(obj.ReferenceTypeName);
                 stringBuilder.Append(':');
-                stringBuilder.Append(obj.ReferenceKey);
+                stringBuilder.Append(obj.GetReferenceKey(this.siteDataIndex));
                 stringBuilder.Append('>');
             }
             else
@@ -24,9 +32,9 @@ namespace GlogGenerator.MarkdownExtensions
                 renderer.WriteChildren(obj);
 
                 stringBuilder.Append("](");
-                stringBuilder.Append(obj.ReferenceType);
+                stringBuilder.Append(obj.ReferenceTypeName);
                 stringBuilder.Append(':');
-                stringBuilder.Append(obj.ReferenceKey);
+                stringBuilder.Append(obj.GetReferenceKey(this.siteDataIndex));
                 stringBuilder.Append(')');
             }
 

--- a/GlogGenerator/MarkdownExtensions/GlogMarkdownExtension.cs
+++ b/GlogGenerator/MarkdownExtensions/GlogMarkdownExtension.cs
@@ -43,8 +43,8 @@ namespace GlogGenerator.MarkdownExtensions
         {
             pipeline.InlineParsers.Insert(0, new ReversibleGenericAttributesParser());
 
-            pipeline.InlineParsers.InsertBefore<AutolinkInlineParser>(new GlogAutoLinkInlineParser());
-            pipeline.InlineParsers.InsertBefore<LinkInlineParser>(new GlogLinkInlineParser());
+            pipeline.InlineParsers.InsertBefore<AutolinkInlineParser>(new GlogAutoLinkInlineParser(this.siteDataIndex));
+            pipeline.InlineParsers.InsertBefore<LinkInlineParser>(new GlogLinkInlineParser(this.siteDataIndex));
 
             pipeline.BlockParsers.AddIfNotAlready<FencedDataBlockParser>();
             pipeline.BlockParsers.AddIfNotAlready<TomlFrontMatterBlockParser>();
@@ -114,7 +114,7 @@ namespace GlogGenerator.MarkdownExtensions
             }
             else if (renderer is NormalizeRenderer)
             {
-                renderer.ObjectRenderers.InsertBefore<Markdig.Renderers.Normalize.Inlines.AutolinkInlineRenderer>(new GlogLinkNormalizeRenderer());
+                renderer.ObjectRenderers.InsertBefore<Markdig.Renderers.Normalize.Inlines.AutolinkInlineRenderer>(new GlogLinkNormalizeRenderer(this.siteDataIndex));
                 renderer.ObjectRenderers.AddIfNotAlready<FencedDataBlockNormalizeRenderer>();
                 renderer.ObjectRenderers.AddIfNotAlready<SpoilerNormalizeRenderer>();
 
@@ -123,7 +123,7 @@ namespace GlogGenerator.MarkdownExtensions
             }
             else if (renderer is RoundtripRenderer)
             {
-                renderer.ObjectRenderers.InsertBefore<Markdig.Renderers.Roundtrip.Inlines.AutolinkInlineRenderer>(new GlogLinkRoundtripRenderer());
+                renderer.ObjectRenderers.InsertBefore<Markdig.Renderers.Roundtrip.Inlines.AutolinkInlineRenderer>(new GlogLinkRoundtripRenderer(this.siteDataIndex));
                 renderer.ObjectRenderers.AddIfNotAlready<FencedDataBlockRoundtripeRenderer>();
                 renderer.ObjectRenderers.AddIfNotAlready<SpoilerRoundtripRenderer>();
 

--- a/GlogGenerator/Program.cs
+++ b/GlogGenerator/Program.cs
@@ -104,6 +104,10 @@ namespace GlogGenerator
                     throw new ArgumentException("Missing or empty --igdb-client-secret");
                 }
 
+                // Ensure that data references are resolved to underlying IDs,
+                // before potentially modifying data keys with this update.
+                builder.ResolveDataReferences();
+
                 using (var igdbApiClient = new IgdbApiClient(logger, igdbClientId, igdbClientSecret))
                 {
                     logger.LogInformation("Updating IGDB cache...");

--- a/GlogGenerator/RenderState/LinkedPostProperties.cs
+++ b/GlogGenerator/RenderState/LinkedPostProperties.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using GlogGenerator.Data;
+
+namespace GlogGenerator.RenderState
+{
+    public class LinkedPostProperties
+    {
+        public List<string> Categories { get; set; } = new List<string>();
+
+        public DateTimeOffset Date { get; set; } = DateTimeOffset.MinValue;
+
+        public List<string> Games { get; set; } = new List<string>();
+
+        public List<string> Platforms { get; set; } = new List<string>();
+
+        public string PermalinkRelative { get; set; } = string.Empty;
+
+        public string Title { get; set; } = string.Empty;
+
+        public static LinkedPostProperties FromPostData(PostData postData, ISiteDataIndex siteDataIndex)
+        {
+            var linkedPostProperties = new LinkedPostProperties();
+
+            linkedPostProperties.Categories = postData.Categories.Select(r => siteDataIndex.GetData(r))
+                .Select(c => c.Name).ToList();
+
+            linkedPostProperties.Date = postData.Date;
+
+            linkedPostProperties.Games = postData.Games.Select(r => siteDataIndex.GetData(r))
+                .Select(c => c.Title).ToList();
+
+            linkedPostProperties.Platforms = postData.Platforms.Select(r => siteDataIndex.GetData(r))
+                .Select(c => c.Abbreviation).ToList();
+
+            linkedPostProperties.PermalinkRelative = postData.PermalinkRelative;
+
+            linkedPostProperties.Title = postData.Title;
+
+            return linkedPostProperties;
+        }
+    }
+}

--- a/GlogGenerator/RenderState/PageState.cs
+++ b/GlogGenerator/RenderState/PageState.cs
@@ -107,7 +107,7 @@ namespace GlogGenerator.RenderState
             }
         }
 
-        public List<PostData> LinkedPosts { get; set; } = new List<PostData>();
+        public List<LinkedPostProperties> LinkedPosts { get; set; } = new List<LinkedPostProperties>();
 
         public int TermsCount
         {
@@ -203,7 +203,7 @@ namespace GlogGenerator.RenderState
             return page;
         }
 
-        public static PageState FromCategoryData(SiteBuilder siteBuilder, CategoryData categoryData)
+        public static PageState FromCategoryData(SiteBuilder siteBuilder, CategoryData categoryData, ISiteDataIndex siteDataIndex)
         {
             var page = new PageState(siteBuilder);
 
@@ -213,7 +213,9 @@ namespace GlogGenerator.RenderState
 
             page.PageType = "categories";
 
-            page.LinkedPosts = categoryData.LinkedPosts.OrderByDescending(p => p.Date).ToList();
+            page.LinkedPosts = categoryData.LinkedPostIds.Select(i => siteDataIndex.GetPostById(i))
+                .Select(p => LinkedPostProperties.FromPostData(p, siteDataIndex))
+                .OrderByDescending(p => p.Date).ToList();
 
             if (page.LinkedPostsCount > 0)
             {
@@ -230,7 +232,7 @@ namespace GlogGenerator.RenderState
             return page;
         }
 
-        public static PageState FromGameData(SiteBuilder siteBuilder, GameData gameData)
+        public static PageState FromGameData(SiteBuilder siteBuilder, GameData gameData, ISiteDataIndex siteDataIndex)
         {
             var page = new PageState(siteBuilder);
 
@@ -243,7 +245,9 @@ namespace GlogGenerator.RenderState
             page.IgdbUrl = gameData.IgdbUrl;
             page.Tags = gameData.Tags;
 
-            page.LinkedPosts = gameData.LinkedPosts.OrderByDescending(p => p.Date).ToList();
+            page.LinkedPosts = gameData.LinkedPostIds.Select(i => siteDataIndex.GetPostById(i))
+                .Select(p => LinkedPostProperties.FromPostData(p, siteDataIndex))
+                .OrderByDescending(p => p.Date).ToList();
 
             if (page.LinkedPostsCount > 0)
             {
@@ -260,7 +264,7 @@ namespace GlogGenerator.RenderState
             return page;
         }
 
-        public static PageState FromPlatformData(SiteBuilder siteBuilder, PlatformData platformData)
+        public static PageState FromPlatformData(SiteBuilder siteBuilder, PlatformData platformData, ISiteDataIndex siteDataIndex)
         {
             var page = new PageState(siteBuilder);
 
@@ -286,7 +290,9 @@ namespace GlogGenerator.RenderState
 
             page.IgdbUrl = platformData.IgdbUrl;
 
-            page.LinkedPosts = platformData.LinkedPosts.OrderByDescending(p => p.Date).ToList();
+            page.LinkedPosts = platformData.LinkedPostIds.Select(i => siteDataIndex.GetPostById(i))
+                .Select(p => LinkedPostProperties.FromPostData(p, siteDataIndex))
+                .OrderByDescending(p => p.Date).ToList();
 
             if (page.LinkedPostsCount > 0)
             {
@@ -303,7 +309,7 @@ namespace GlogGenerator.RenderState
             return page;
         }
 
-        public static PageState FromRatingData(SiteBuilder siteBuilder, RatingData ratingData)
+        public static PageState FromRatingData(SiteBuilder siteBuilder, RatingData ratingData, ISiteDataIndex siteDataIndex)
         {
             var page = new PageState(siteBuilder);
 
@@ -313,7 +319,9 @@ namespace GlogGenerator.RenderState
 
             page.PageType = "ratings";
 
-            page.LinkedPosts = ratingData.LinkedPosts.OrderByDescending(p => p.Date).ToList();
+            page.LinkedPosts = ratingData.LinkedPostIds.Select(i => siteDataIndex.GetPostById(i))
+                .Select(p => LinkedPostProperties.FromPostData(p, siteDataIndex))
+                .OrderByDescending(p => p.Date).ToList();
 
             if (page.LinkedPostsCount > 0)
             {
@@ -330,7 +338,7 @@ namespace GlogGenerator.RenderState
             return page;
         }
 
-        public static PageState FromTagData(SiteBuilder siteBuilder, TagData tagData)
+        public static PageState FromTagData(SiteBuilder siteBuilder, TagData tagData, ISiteDataIndex siteDataIndex)
         {
             var page = new PageState(siteBuilder);
 
@@ -340,7 +348,9 @@ namespace GlogGenerator.RenderState
 
             page.PageType = "tags";
 
-            page.LinkedPosts = tagData.LinkedPosts.OrderByDescending(p => p.Date).ToList();
+            page.LinkedPosts = tagData.LinkedPostIds.Select(i => siteDataIndex.GetPostById(i))
+                .Select(p => LinkedPostProperties.FromPostData(p, siteDataIndex))
+                .OrderByDescending(p => p.Date).ToList();
 
             if (page.LinkedPostsCount > 0)
             {

--- a/GlogGenerator/RenderState/PageState.cs
+++ b/GlogGenerator/RenderState/PageState.cs
@@ -168,23 +168,23 @@ namespace GlogGenerator.RenderState
             return page;
         }
 
-        public static PageState FromPostData(SiteBuilder siteBuilder, PostData postData)
+        public static PageState FromPostData(SiteBuilder siteBuilder, PostData postData, ISiteDataIndex siteDataIndex)
         {
             var page = new PageState(siteBuilder);
 
-            page.Categories = postData.Categories.Select(c => new CategoryData() { Name = c }).ToList();
+            page.Categories = postData.Categories.Select(r => siteDataIndex.GetData(r)).ToList();
 
             page.Date = postData.Date;
 
-            page.Games = postData.Games?.Select(c => new GameData() { Title = c }).ToList();
+            page.Games = postData.Games?.Select(r => siteDataIndex.GetData(r)).ToList();
 
             page.HideDate = (postData.Date == DateTimeOffset.MinValue);
 
             page.Permalink = $"{siteBuilder.GetBaseURL()}{postData.PermalinkRelative}";
 
-            page.Platforms = postData.Platforms?.Select(c => new PlatformData() { Abbreviation = c }).ToList();
+            page.Platforms = postData.Platforms?.Select(r => siteDataIndex.GetData(r)).ToList();
 
-            page.Ratings = postData.Ratings?.Select(c => new RatingData() { Name = c }).ToList();
+            page.Ratings = postData.Ratings?.Select(r => siteDataIndex.GetData(r)).ToList();
 
             page.Title = postData.Title;
 

--- a/GlogGenerator/SiteBuilder.cs
+++ b/GlogGenerator/SiteBuilder.cs
@@ -293,7 +293,7 @@ namespace GlogGenerator
                     Permalink = $"{this.GetBaseURL()}post/",
                     OutputPathRelative = "post/index.html",
                     RenderTemplateName = "list",
-                    LinkedPosts = posts,
+                    LinkedPosts = posts.Select(p => LinkedPostProperties.FromPostData(p, this.siteDataIndex)).ToList(),
                 };
                 contentRoutes.Add(postsListPage.OutputPathRelative, postsListPage);
 
@@ -388,7 +388,7 @@ namespace GlogGenerator
             {
                 foreach (var categoryData in categories)
                 {
-                    var page = PageState.FromCategoryData(this, categoryData);
+                    var page = PageState.FromCategoryData(this, categoryData, this.siteDataIndex);
                     contentRoutes.Add(page.OutputPathRelative, page);
                 }
             }
@@ -411,7 +411,7 @@ namespace GlogGenerator
 
                 foreach (var gameData in games)
                 {
-                    var page = PageState.FromGameData(this, gameData);
+                    var page = PageState.FromGameData(this, gameData, this.siteDataIndex);
                     contentRoutes.Add(page.OutputPathRelative, page);
                 }
             }
@@ -434,7 +434,7 @@ namespace GlogGenerator
 
                 foreach (var platformData in platforms)
                 {
-                    var page = PageState.FromPlatformData(this, platformData);
+                    var page = PageState.FromPlatformData(this, platformData, this.siteDataIndex);
                     contentRoutes.Add(page.OutputPathRelative, page);
                 }
             }
@@ -457,7 +457,7 @@ namespace GlogGenerator
 
                 foreach (var ratingData in ratings)
                 {
-                    var page = PageState.FromRatingData(this, ratingData);
+                    var page = PageState.FromRatingData(this, ratingData, this.siteDataIndex);
                     contentRoutes.Add(page.OutputPathRelative, page);
                 }
             }
@@ -480,7 +480,7 @@ namespace GlogGenerator
 
                 foreach (var tagData in tags)
                 {
-                    var page = PageState.FromTagData(this, tagData);
+                    var page = PageState.FromTagData(this, tagData, this.siteDataIndex);
                     contentRoutes.Add(page.OutputPathRelative, page);
                 }
             }

--- a/GlogGenerator/SiteBuilder.cs
+++ b/GlogGenerator/SiteBuilder.cs
@@ -55,7 +55,7 @@ namespace GlogGenerator
             }
             else
             {
-                this.siteDataIndex = new SiteDataIndex(this.logger, this, this.configData.InputFilesBasePath);
+                this.siteDataIndex = new SiteDataIndex(this.logger, this.configData.InputFilesBasePath);
             }
 
             this.siteState = new SiteState(this, this.configData.TemplateFilesBasePath);
@@ -107,7 +107,12 @@ namespace GlogGenerator
         public void UpdateDataIndex()
         {
             var igdbCache = this.GetIgdbCache();
-            this.siteDataIndex.LoadContent(igdbCache);
+            this.siteDataIndex.LoadContent(igdbCache, this.GetMarkdownPipeline());
+        }
+
+        public void ResolveDataReferences()
+        {
+            this.siteDataIndex.ResolveReferences();
         }
 
         public List<PageData> GetPages()
@@ -122,7 +127,7 @@ namespace GlogGenerator
 
         public void RewriteData()
         {
-            this.siteDataIndex.RewriteSourceContent();
+            this.siteDataIndex.RewriteSourceContent(this.GetMarkdownPipeline());
         }
 
         public List<GameStats> GetGameStatsForDateRange(DateTimeOffset startDate, DateTimeOffset endDate)

--- a/GlogGenerator/SiteBuilder.cs
+++ b/GlogGenerator/SiteBuilder.cs
@@ -133,23 +133,25 @@ namespace GlogGenerator
             {
                 if (reportPost.Games != null)
                 {
-                    foreach (var postGame in reportPost.Games)
+                    foreach (var postGameReference in reportPost.Games)
                     {
+                        var postGameData = this.siteDataIndex.GetData(postGameReference);
+
                         if (reportPost.Platforms != null)
                         {
-                            foreach (var postPlatform in reportPost.Platforms)
+                            foreach (var postPlatformReference in reportPost.Platforms)
                             {
-                                var gameAndPlatformKey = $"{postGame}__{postPlatform}";
+                                var postPlatformData = this.siteDataIndex.GetData(postPlatformReference);
+
+                                var gameAndPlatformKey = $"{postGameData.GetDataId()}:{postPlatformData.GetDataId()}";
 
                                 if (!statsByGameAndPlatform.ContainsKey(gameAndPlatformKey))
                                 {
-                                    var gameData = this.siteDataIndex.GetGame(postGame);
-
                                     statsByGameAndPlatform[gameAndPlatformKey] = new GameStats()
                                     {
-                                        Title = postGame,
-                                        Platform = postPlatform,
-                                        Type = gameData.IgdbCategory.Description(),
+                                        Title = postGameData.Title,
+                                        Platform = postPlatformData.Abbreviation,
+                                        Type = postGameData.IgdbCategory.Description(),
                                         FirstPosted = reportPost.Date,
                                         LastPosted = reportPost.Date,
                                     };
@@ -167,7 +169,10 @@ namespace GlogGenerator
 
                                 if (reportPost.Ratings != null && reportPost.Ratings.Count > 0)
                                 {
-                                    statsByGameAndPlatform[gameAndPlatformKey].Rating = reportPost.Ratings[0];
+                                    var postRatingReference = reportPost.Ratings[0];
+                                    var postRatingData = this.siteDataIndex.GetData(postRatingReference);
+
+                                    statsByGameAndPlatform[gameAndPlatformKey].Rating = postRatingData.Name;
                                 }
 
                                 ++statsByGameAndPlatform[gameAndPlatformKey].NumPosts;
@@ -264,13 +269,13 @@ namespace GlogGenerator
                         if (postData.Games != null)
                         {
                             // Verify that the post's games are found in our metadata cache.
-                            foreach (var game in postData.Games)
+                            foreach (var gameReference in postData.Games)
                             {
-                                _ = this.siteDataIndex.GetGame(game);
+                                _ = this.siteDataIndex.GetData(gameReference);
                             }
                         }
 
-                        var page = PageState.FromPostData(this, postData);
+                        var page = PageState.FromPostData(this, postData, this.siteDataIndex);
                         postPages.Add(page);
                         contentRoutes.Add(page.OutputPathRelative, page);
                     }


### PR DESCRIPTION
(Or: when a game title changes, rendering can now use the new title.)

By creating these "references" at parse-time / when building site data from markup, and then ensuring those references point to consistent data IDs, subsequent processing - such as updating site data from IGDB, which can include modifying referenceable name strings - *avoids* breaking the pre-existing references (to unchanged underlying IDs).

Content rendering uses the SiteDataReference, rather than the original referenceable string, so changes to that string can be dynamically fetched at render-time.  In other words, output uses the new data, instead of the old data from parsed input.

Furthermore, since other recent changes to implement markdown (and toml) roundtrip rendering, using SiteDataReferences when "rewriting input files" means that the input can be rewritten *with modified data*, so that if a reference string is changed, input will be patched to match it.

That corrective input-rewriting is now included in the automated CI + schedule workflow, so, summarily: when IGDB data changes imply a reference key change (like a game title), the GitHub workflow should now automatically adapt to it.