### PR TITLE
When the release year isn't enough: append a game's platforms to the display name.

### DIFF
--- a/GlogGenerator.Test/Data/SiteDataIndexTests.cs
+++ b/GlogGenerator.Test/Data/SiteDataIndexTests.cs
@@ -78,7 +78,7 @@ namespace GlogGenerator.Test.Data
             var errors = logger.GetLogs(LogLevel.Error);
             Assert.AreEqual(1, errors.Count);
 
-            var expectedMessage = $"Updated data index has a different key for GameData with data ID {testDataItem.GetUniqueIdString()}: old key Some Game Name new key Corrected Game Name";
+            var expectedMessage = $"Updated data index has a different key for GameData with data ID {testDataItem.GetUniqueIdString(mockIgdbCache)}: old key Some Game Name new key Corrected Game Name";
             Assert.AreEqual(expectedMessage, errors[0].Message);
 
             Assert.AreEqual(0, logger.GetLogs(LogLevel.Warning).Count);
@@ -119,7 +119,7 @@ namespace GlogGenerator.Test.Data
             var errors = logger.GetLogs(LogLevel.Error);
             Assert.AreEqual(1, errors.Count);
 
-            var expectedMessage = $"Updated data index has a different key for PlatformData with data ID {testPlatformOld.GetUniqueIdString()}: old key {testPlatformOld.GetReferenceableValue()} new key {testPlatformNew.GetReferenceableValue()}";
+            var expectedMessage = $"Updated data index has a different key for PlatformData with data ID {testPlatformOld.GetUniqueIdString(mockIgdbCache)}: old key {testPlatformOld.GetReferenceString(mockIgdbCache)} new key {testPlatformNew.GetReferenceString(mockIgdbCache)}";
             Assert.AreEqual(expectedMessage, errors[0].Message);
 
             Assert.AreEqual(0, logger.GetLogs(LogLevel.Warning).Count);
@@ -152,7 +152,7 @@ namespace GlogGenerator.Test.Data
             var errors = logger.GetLogs(LogLevel.Error);
             Assert.AreEqual(1, errors.Count);
 
-            var expectedMessage = $"Updated data index is missing old PlatformData with data ID {testPlatformOld.GetUniqueIdString()} and key {testPlatformOld.GetReferenceableValue()}";
+            var expectedMessage = $"Updated data index is missing old PlatformData with data ID {testPlatformOld.GetUniqueIdString(mockIgdbCache)} and key {testPlatformOld.GetReferenceString(mockIgdbCache)}";
             Assert.AreEqual(expectedMessage, errors[0].Message);
 
             Assert.AreEqual(0, logger.GetLogs(LogLevel.Warning).Count);
@@ -189,7 +189,7 @@ namespace GlogGenerator.Test.Data
             var warnings = logger.GetLogs(LogLevel.Warning);
             Assert.AreEqual(1, warnings.Count);
 
-            var expectedMessage = $"Updated data index has a different data ID for PlatformData with key {testPlatformOld.GetReferenceableValue()}: old data ID {testPlatformOld.GetUniqueIdString()} new data ID {testPlatformNew.GetUniqueIdString()}";
+            var expectedMessage = $"Updated data index has a different data ID for PlatformData with key {testPlatformOld.GetReferenceString(mockIgdbCache)}: old data ID {testPlatformOld.GetUniqueIdString(mockIgdbCache)} new data ID {testPlatformNew.GetUniqueIdString(mockIgdbCache)}";
             Assert.AreEqual(expectedMessage, warnings[0].Message);
         }
     }

--- a/GlogGenerator.Test/Data/SiteDataIndexTests.cs
+++ b/GlogGenerator.Test/Data/SiteDataIndexTests.cs
@@ -119,7 +119,7 @@ namespace GlogGenerator.Test.Data
             var errors = logger.GetLogs(LogLevel.Error);
             Assert.AreEqual(1, errors.Count);
 
-            var expectedMessage = $"Updated data index has a different key for PlatformData with data ID {testPlatformOld.GetUniqueIdString()}: old key {testPlatformOld.GetReferenceableKey()} new key {testPlatformNew.GetReferenceableKey()}";
+            var expectedMessage = $"Updated data index has a different key for PlatformData with data ID {testPlatformOld.GetUniqueIdString()}: old key {testPlatformOld.GetReferenceableValue()} new key {testPlatformNew.GetReferenceableValue()}";
             Assert.AreEqual(expectedMessage, errors[0].Message);
 
             Assert.AreEqual(0, logger.GetLogs(LogLevel.Warning).Count);
@@ -152,7 +152,7 @@ namespace GlogGenerator.Test.Data
             var errors = logger.GetLogs(LogLevel.Error);
             Assert.AreEqual(1, errors.Count);
 
-            var expectedMessage = $"Updated data index is missing old PlatformData with data ID {testPlatformOld.GetUniqueIdString()} and key {testPlatformOld.GetReferenceableKey()}";
+            var expectedMessage = $"Updated data index is missing old PlatformData with data ID {testPlatformOld.GetUniqueIdString()} and key {testPlatformOld.GetReferenceableValue()}";
             Assert.AreEqual(expectedMessage, errors[0].Message);
 
             Assert.AreEqual(0, logger.GetLogs(LogLevel.Warning).Count);
@@ -189,7 +189,7 @@ namespace GlogGenerator.Test.Data
             var warnings = logger.GetLogs(LogLevel.Warning);
             Assert.AreEqual(1, warnings.Count);
 
-            var expectedMessage = $"Updated data index has a different data ID for PlatformData with key {testPlatformOld.GetReferenceableKey()}: old data ID {testPlatformOld.GetUniqueIdString()} new data ID {testPlatformNew.GetUniqueIdString()}";
+            var expectedMessage = $"Updated data index has a different data ID for PlatformData with key {testPlatformOld.GetReferenceableValue()}: old data ID {testPlatformOld.GetUniqueIdString()} new data ID {testPlatformNew.GetUniqueIdString()}";
             Assert.AreEqual(expectedMessage, warnings[0].Message);
         }
     }

--- a/GlogGenerator/Data/GameData.cs
+++ b/GlogGenerator/Data/GameData.cs
@@ -54,10 +54,10 @@ namespace GlogGenerator.Data
         public static GameData FromIgdbGame(IIgdbCache igdbCache, IgdbGame igdbGame)
         {
             var game = new GameData();
-            game.dataId = igdbGame.GetUniqueIdString();
-            game.referenceableKey = igdbGame.GetReferenceableValue();
+            game.dataId = igdbGame.GetUniqueIdString(igdbCache);
+            game.referenceableKey = igdbGame.GetReferenceString(igdbCache);
 
-            game.Title = igdbGame.NameForGlog;
+            game.Title = igdbGame.GetReferenceString(igdbCache);
 
             if (igdbGame.Category != IgdbGameCategory.None)
             {
@@ -73,7 +73,7 @@ namespace GlogGenerator.Data
             if (igdbGame.MainCollectionId != IgdbCollection.IdNotFound)
             {
                 var collection = igdbCache.GetCollection(igdbGame.MainCollectionId);
-                if (collection != null && !game.Tags.Contains(collection.GetReferenceableValue(), StringComparer.OrdinalIgnoreCase))
+                if (collection != null && !game.Tags.Contains(collection.GetReferenceString(igdbCache), StringComparer.OrdinalIgnoreCase))
                 {
                     game.Tags.Add(collection.Name);
                 }
@@ -82,27 +82,27 @@ namespace GlogGenerator.Data
             foreach (var collectionId in igdbGame.CollectionIds)
             {
                 var collection = igdbCache.GetCollection(collectionId);
-                if (collection != null && !game.Tags.Contains(collection.GetReferenceableValue(), StringComparer.OrdinalIgnoreCase))
+                if (collection != null && !game.Tags.Contains(collection.GetReferenceString(igdbCache), StringComparer.OrdinalIgnoreCase))
                 {
-                    game.Tags.Add(collection.GetReferenceableValue());
+                    game.Tags.Add(collection.GetReferenceString(igdbCache));
                 }
             }
 
             if (igdbGame.MainFranchiseId != IgdbFranchise.IdNotFound)
             {
                 var franchise = igdbCache.GetFranchise(igdbGame.MainFranchiseId);
-                if (franchise != null && !game.Tags.Contains(franchise.GetReferenceableValue(), StringComparer.OrdinalIgnoreCase))
+                if (franchise != null && !game.Tags.Contains(franchise.GetReferenceString(igdbCache), StringComparer.OrdinalIgnoreCase))
                 {
-                    game.Tags.Add(franchise.GetReferenceableValue());
+                    game.Tags.Add(franchise.GetReferenceString(igdbCache));
                 }
             }
 
             foreach (var franchiseId in igdbGame.FranchiseIds)
             {
                 var franchise = igdbCache.GetFranchise(franchiseId);
-                if (franchise != null && !game.Tags.Contains(franchise.GetReferenceableValue(), StringComparer.OrdinalIgnoreCase))
+                if (franchise != null && !game.Tags.Contains(franchise.GetReferenceString(igdbCache), StringComparer.OrdinalIgnoreCase))
                 {
-                    game.Tags.Add(franchise.GetReferenceableValue());
+                    game.Tags.Add(franchise.GetReferenceString(igdbCache));
                 }
             }
 
@@ -122,54 +122,54 @@ namespace GlogGenerator.Data
             foreach (var companyId in companyIds)
             {
                 var company = igdbCache.GetCompany(companyId);
-                if (company != null && !game.Tags.Contains(company.GetReferenceableValue(), StringComparer.OrdinalIgnoreCase))
+                if (company != null && !game.Tags.Contains(company.GetReferenceString(igdbCache), StringComparer.OrdinalIgnoreCase))
                 {
-                    game.Tags.Add(company.GetReferenceableValue());
+                    game.Tags.Add(company.GetReferenceString(igdbCache));
                 }
             }
 
             foreach (var genreId in igdbGame.GenreIds)
             {
                 var genre = igdbCache.GetGenre(genreId);
-                if (genre != null && !game.Tags.Contains(genre.GetReferenceableValue(), StringComparer.OrdinalIgnoreCase))
+                if (genre != null && !game.Tags.Contains(genre.GetReferenceString(igdbCache), StringComparer.OrdinalIgnoreCase))
                 {
-                    game.Tags.Add(genre.GetReferenceableValue());
+                    game.Tags.Add(genre.GetReferenceString(igdbCache));
                 }
             }
 
             foreach (var gameModeId in igdbGame.GameModeIds)
             {
                 var gameMode = igdbCache.GetGameMode(gameModeId);
-                if (gameMode != null && !game.Tags.Contains(gameMode.GetReferenceableValue(), StringComparer.OrdinalIgnoreCase))
+                if (gameMode != null && !game.Tags.Contains(gameMode.GetReferenceString(igdbCache), StringComparer.OrdinalIgnoreCase))
                 {
-                    game.Tags.Add(gameMode.GetReferenceableValue());
+                    game.Tags.Add(gameMode.GetReferenceString(igdbCache));
                 }
             }
 
             foreach (var keywordId in igdbGame.KeywordIds)
             {
                 var keyword = igdbCache.GetKeyword(keywordId);
-                if (keyword != null && !game.Tags.Contains(keyword.GetReferenceableValue(), StringComparer.OrdinalIgnoreCase))
+                if (keyword != null && !game.Tags.Contains(keyword.GetReferenceString(igdbCache), StringComparer.OrdinalIgnoreCase))
                 {
-                    game.Tags.Add(keyword.GetReferenceableValue());
+                    game.Tags.Add(keyword.GetReferenceString(igdbCache));
                 }
             }
 
             foreach (var playerPerspectiveId in igdbGame.PlayerPerspectiveIds)
             {
                 var playerPerspective = igdbCache.GetPlayerPerspective(playerPerspectiveId);
-                if (playerPerspective != null && !game.Tags.Contains(playerPerspective.GetReferenceableValue(), StringComparer.OrdinalIgnoreCase))
+                if (playerPerspective != null && !game.Tags.Contains(playerPerspective.GetReferenceString(igdbCache), StringComparer.OrdinalIgnoreCase))
                 {
-                    game.Tags.Add(playerPerspective.GetReferenceableValue());
+                    game.Tags.Add(playerPerspective.GetReferenceString(igdbCache));
                 }
             }
 
             foreach (var themeId in igdbGame.ThemeIds)
             {
                 var theme = igdbCache.GetTheme(themeId);
-                if (theme != null && !game.Tags.Contains(theme.GetReferenceableValue(), StringComparer.OrdinalIgnoreCase))
+                if (theme != null && !game.Tags.Contains(theme.GetReferenceString(igdbCache), StringComparer.OrdinalIgnoreCase))
                 {
-                    game.Tags.Add(theme.GetReferenceableValue());
+                    game.Tags.Add(theme.GetReferenceString(igdbCache));
                 }
             }
 
@@ -214,7 +214,7 @@ namespace GlogGenerator.Data
                 var bundleGame = igdbCache.GetGame(relatedGameId);
                 if (bundleGame != null)
                 {
-                    game.LinkPostsToOtherGames.Add(bundleGame.GetReferenceableValue());
+                    game.LinkPostsToOtherGames.Add(bundleGame.GetReferenceString(igdbCache));
                 }
             }
 
@@ -266,9 +266,9 @@ namespace GlogGenerator.Data
             if (gameId != IgdbEntity.IdNotFound)
             {
                 var relatedGame = igdbCache.GetGame(gameId);
-                if (relatedGame != null && !this.RelatedGames.Contains(relatedGame.GetReferenceableValue(), StringComparer.OrdinalIgnoreCase))
+                if (relatedGame != null && !this.RelatedGames.Contains(relatedGame.GetReferenceString(igdbCache), StringComparer.OrdinalIgnoreCase))
                 {
-                    this.RelatedGames.Add(relatedGame.GetReferenceableValue());
+                    this.RelatedGames.Add(relatedGame.GetReferenceString(igdbCache));
                 }
             }
         }

--- a/GlogGenerator/Data/GameData.cs
+++ b/GlogGenerator/Data/GameData.cs
@@ -55,7 +55,7 @@ namespace GlogGenerator.Data
         {
             var game = new GameData();
             game.dataId = igdbGame.GetUniqueIdString();
-            game.referenceableKey = igdbGame.GetReferenceableKey();
+            game.referenceableKey = igdbGame.GetReferenceableValue();
 
             game.Title = igdbGame.NameForGlog;
 

--- a/GlogGenerator/Data/PlatformData.cs
+++ b/GlogGenerator/Data/PlatformData.cs
@@ -47,10 +47,10 @@ namespace GlogGenerator.Data
         public static PlatformData FromIgdbPlatform(IIgdbCache igdbCache, IgdbPlatform igdbPlatform)
         {
             var platform = new PlatformData();
-            platform.dataId = igdbPlatform.GetUniqueIdString();
-            platform.referenceableKey = igdbPlatform.GetReferenceableValue();
+            platform.dataId = igdbPlatform.GetUniqueIdString(igdbCache);
+            platform.referenceableKey = igdbPlatform.GetReferenceString(igdbCache);
 
-            platform.Abbreviation = igdbPlatform.AbbreviationForGlog;
+            platform.Abbreviation = igdbPlatform.GetReferenceString(igdbCache);
             platform.Name = igdbPlatform.Name;
 
             if (!string.IsNullOrEmpty(igdbPlatform.Url))

--- a/GlogGenerator/Data/PlatformData.cs
+++ b/GlogGenerator/Data/PlatformData.cs
@@ -48,7 +48,7 @@ namespace GlogGenerator.Data
         {
             var platform = new PlatformData();
             platform.dataId = igdbPlatform.GetUniqueIdString();
-            platform.referenceableKey = igdbPlatform.GetReferenceableKey();
+            platform.referenceableKey = igdbPlatform.GetReferenceableValue();
 
             platform.Abbreviation = igdbPlatform.AbbreviationForGlog;
             platform.Name = igdbPlatform.Name;

--- a/GlogGenerator/Data/SiteDataIndex.cs
+++ b/GlogGenerator/Data/SiteDataIndex.cs
@@ -320,7 +320,7 @@ namespace GlogGenerator.Data
 
             foreach (var igdbGameMetadata in igdbCache.GetAllGameMetadata())
             {
-                var tagName = igdbGameMetadata.GetReferenceableValue();
+                var tagName = igdbGameMetadata.GetReferenceString(igdbCache);
 
                 CreateOrMergeMultiKeyReferenceableData(this.tags, tagName);
             }

--- a/GlogGenerator/IIgdbCache.cs
+++ b/GlogGenerator/IIgdbCache.cs
@@ -30,6 +30,8 @@ namespace GlogGenerator
 
         public IgdbPlayerPerspective GetPlayerPerspective(int id);
 
+        public IgdbReleaseDate GetReleaseDate(int id);
+
         public IgdbTheme GetTheme(int id);
 
         public List<IgdbEntity> GetAllGameMetadata();

--- a/GlogGenerator/IgdbApi/IgdbCollection.cs
+++ b/GlogGenerator/IgdbApi/IgdbCollection.cs
@@ -11,9 +11,13 @@ namespace GlogGenerator.IgdbApi
         [JsonProperty("id")]
         public int Id { get; set; }
 
-        [IgdbEntityReferenceableValue]
         [JsonProperty("name", Required = Required.Always)]
         public string Name { get; set; }
+
+        public override string GetReferenceString(IIgdbCache cache)
+        {
+            return this.Name;
+        }
     }
 #pragma warning restore CA1711 // Identifiers should not have incorrect suffix
 }

--- a/GlogGenerator/IgdbApi/IgdbCompany.cs
+++ b/GlogGenerator/IgdbApi/IgdbCompany.cs
@@ -10,8 +10,12 @@ namespace GlogGenerator.IgdbApi
         [JsonProperty("id")]
         public int Id { get; set; }
 
-        [IgdbEntityReferenceableValue]
         [JsonProperty("name", Required = Required.Always)]
         public string Name { get; set; }
+
+        public override string GetReferenceString(IIgdbCache cache)
+        {
+            return this.Name;
+        }
     }
 }

--- a/GlogGenerator/IgdbApi/IgdbEntity.cs
+++ b/GlogGenerator/IgdbApi/IgdbEntity.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Security.Cryptography;
@@ -66,9 +67,11 @@ namespace GlogGenerator.IgdbApi
 
         public string GetUniqueIdString()
         {
+            var entityType = this.GetType();
+
             using (var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256))
             {
-                var typeBytes = Encoding.UTF8.GetBytes(nameof(GameData));
+                var typeBytes = Encoding.UTF8.GetBytes(entityType.Name);
                 hash.AppendData(typeBytes);
 
                 var entityId = this.GetEntityId();
@@ -79,7 +82,13 @@ namespace GlogGenerator.IgdbApi
                 }
                 else
                 {
-                    var keyBytes = Encoding.UTF8.GetBytes(this.GetReferenceableValue());
+                    var referenceableValue = this.GetReferenceableValue();
+                    if (referenceableValue == null)
+                    {
+                        throw new InvalidDataException($"An {entityType} is unable to generate a unique ID string because it has no Entity ID and no Referenceable Value");
+                    }
+
+                    var keyBytes = Encoding.UTF8.GetBytes(referenceableValue);
                     hash.AppendData(keyBytes);
                 }
 
@@ -99,11 +108,6 @@ namespace GlogGenerator.IgdbApi
             {
                 return null;
             }
-        }
-
-        public string GetReferenceableKey()
-        {
-            return this.GetReferenceableValue();
         }
 
         public Dictionary<string, object> GetGlogOverrideValues()

--- a/GlogGenerator/IgdbApi/IgdbFranchise.cs
+++ b/GlogGenerator/IgdbApi/IgdbFranchise.cs
@@ -10,8 +10,12 @@ namespace GlogGenerator.IgdbApi
         [JsonProperty("id")]
         public int Id { get; set; }
 
-        [IgdbEntityReferenceableValue]
         [JsonProperty("name", Required = Required.Always)]
         public string Name { get; set; }
+
+        public override string GetReferenceString(IIgdbCache cache)
+        {
+            return this.Name;
+        }
     }
 }

--- a/GlogGenerator/IgdbApi/IgdbGame.cs
+++ b/GlogGenerator/IgdbApi/IgdbGame.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text;
 using Newtonsoft.Json;
 
 namespace GlogGenerator.IgdbApi
@@ -37,7 +38,12 @@ namespace GlogGenerator.IgdbApi
         {
             get
             {
-                return DateTimeOffset.FromUnixTimeSeconds(this.FirstReleaseDateTimestamp);
+                if (this.FirstReleaseDateTimestamp != 0)
+                {
+                    return DateTimeOffset.FromUnixTimeSeconds(this.FirstReleaseDateTimestamp);
+                }
+
+                return DateTimeOffset.MinValue;
             }
         }
 
@@ -88,12 +94,17 @@ namespace GlogGenerator.IgdbApi
                     return this.NameGlogOverride;
                 }
 
+                var nameBuilder = new StringBuilder();
+                nameBuilder.Append(this.Name);
+
                 if (this.NameGlogAppendReleaseYear == true)
                 {
-                    return $"{this.Name} ({this.FirstReleaseDate.Year})";
+                    nameBuilder.Append(" (");
+                    nameBuilder.Append(this.FirstReleaseDate.Year);
+                    nameBuilder.Append(")");
                 }
 
-                return this.Name;
+                return nameBuilder.ToString();
             }
         }
 

--- a/GlogGenerator/IgdbApi/IgdbGame.cs
+++ b/GlogGenerator/IgdbApi/IgdbGame.cs
@@ -64,6 +64,10 @@ namespace GlogGenerator.IgdbApi
         public string Name { get; set; }
 
         [IgdbEntityGlogOverrideValue]
+        [JsonProperty("name_glogAppendPlatforms")]
+        public bool? NameGlogAppendPlatforms { get; set; } = null;
+
+        [IgdbEntityGlogOverrideValue]
         [JsonProperty("name_glogAppendReleaseYear")]
         public bool? NameGlogAppendReleaseYear { get; set; } = null;
 
@@ -140,6 +144,21 @@ namespace GlogGenerator.IgdbApi
 
                 nameBuilder.Append(" (");
                 nameBuilder.Append(firstReleaseDate.Value.Year);
+                nameBuilder.Append(")");
+            }
+
+            if (this.NameGlogAppendPlatforms == true)
+            {
+                var platforms = this.PlatformIds.Select(id => cache.GetPlatform(id));
+                if (!platforms.Any())
+                {
+                    throw new InvalidDataException($"Game ID {this.Id} named \"{this.Name}\" is set to append platforms to its name, but has no valid platforms.");
+                }
+
+                var platformStringsOrdered = platforms.Select(p => p.GetReferenceString(cache)).OrderBy(s => s);
+
+                nameBuilder.Append(" (");
+                nameBuilder.Append(string.Join(", ", platformStringsOrdered));
                 nameBuilder.Append(")");
             }
 

--- a/GlogGenerator/IgdbApi/IgdbGame.cs
+++ b/GlogGenerator/IgdbApi/IgdbGame.cs
@@ -74,6 +74,9 @@ namespace GlogGenerator.IgdbApi
         [JsonProperty("parent_game")]
         public int ParentGameId { get; set; } = IdNotFound;
 
+        [JsonProperty("platforms")]
+        public List<int> PlatformIds { get; set; } = new List<int>();
+
         [JsonProperty("player_perspectives")]
         public List<int> PlayerPerspectiveIds { get; set; } = new List<int>();
 

--- a/GlogGenerator/IgdbApi/IgdbGameMode.cs
+++ b/GlogGenerator/IgdbApi/IgdbGameMode.cs
@@ -10,8 +10,12 @@ namespace GlogGenerator.IgdbApi
         [JsonProperty("id")]
         public int Id { get; set; }
 
-        [IgdbEntityReferenceableValue]
         [JsonProperty("name", Required = Required.Always)]
         public string Name { get; set; }
+
+        public override string GetReferenceString(IIgdbCache cache)
+        {
+            return this.Name;
+        }
     }
 }

--- a/GlogGenerator/IgdbApi/IgdbGenre.cs
+++ b/GlogGenerator/IgdbApi/IgdbGenre.cs
@@ -10,8 +10,12 @@ namespace GlogGenerator.IgdbApi
         [JsonProperty("id")]
         public int Id { get; set; }
 
-        [IgdbEntityReferenceableValue]
         [JsonProperty("name", Required = Required.Always)]
         public string Name { get; set; }
+
+        public override string GetReferenceString(IIgdbCache cache)
+        {
+            return this.Name;
+        }
     }
 }

--- a/GlogGenerator/IgdbApi/IgdbKeyword.cs
+++ b/GlogGenerator/IgdbApi/IgdbKeyword.cs
@@ -10,8 +10,12 @@ namespace GlogGenerator.IgdbApi
         [JsonProperty("id")]
         public int Id { get; set; }
 
-        [IgdbEntityReferenceableValue]
         [JsonProperty("name", Required = Required.Always)]
         public string Name { get; set; }
+
+        public override string GetReferenceString(IIgdbCache cache)
+        {
+            return this.Name;
+        }
     }
 }

--- a/GlogGenerator/IgdbApi/IgdbPlatform.cs
+++ b/GlogGenerator/IgdbApi/IgdbPlatform.cs
@@ -15,16 +15,6 @@ namespace GlogGenerator.IgdbApi
         [JsonProperty("abbreviation_glogOverride")]
         public string AbbreviationGlogOverride { get; set; }
 
-        [IgdbEntityReferenceableValue]
-        [JsonIgnore]
-        public string AbbreviationForGlog
-        {
-            get
-            {
-                return this.AbbreviationGlogOverride ?? this.Abbreviation;
-            }
-        }
-
         [IgdbEntityId]
         [JsonProperty("id")]
         public int Id { get; set; } = IdNotFound;
@@ -34,5 +24,15 @@ namespace GlogGenerator.IgdbApi
 
         [JsonProperty("url")]
         public string Url { get; set; }
+
+        public override string GetReferenceString(IIgdbCache cache)
+        {
+            if (!string.IsNullOrEmpty(this.AbbreviationGlogOverride))
+            {
+                return this.AbbreviationGlogOverride;
+            }
+
+            return this.Abbreviation;
+        }
     }
 }

--- a/GlogGenerator/IgdbApi/IgdbPlatform.cs
+++ b/GlogGenerator/IgdbApi/IgdbPlatform.cs
@@ -8,12 +8,15 @@ namespace GlogGenerator.IgdbApi
     // This class is NOT a complete representation, it only includes properties as-needed.
     public class IgdbPlatform : IgdbEntity
     {
-        [JsonProperty("abbreviation", Required = Required.Always)]
+        [JsonProperty("abbreviation")]
         public string Abbreviation { get; set; }
 
         [IgdbEntityGlogOverrideValue]
         [JsonProperty("abbreviation_glogOverride")]
         public string AbbreviationGlogOverride { get; set; }
+
+        [JsonProperty("alternative_name")]
+        public string AlternativeName { get; set; }
 
         [IgdbEntityId]
         [JsonProperty("id")]
@@ -32,7 +35,17 @@ namespace GlogGenerator.IgdbApi
                 return this.AbbreviationGlogOverride;
             }
 
-            return this.Abbreviation;
+            if (!string.IsNullOrEmpty(this.Abbreviation))
+            {
+                return this.Abbreviation;
+            }
+
+            if (!string.IsNullOrEmpty(this.AlternativeName))
+            {
+                return this.AlternativeName;
+            }
+
+            return this.Name;
         }
     }
 }

--- a/GlogGenerator/IgdbApi/IgdbPlayerPerspective.cs
+++ b/GlogGenerator/IgdbApi/IgdbPlayerPerspective.cs
@@ -10,8 +10,12 @@ namespace GlogGenerator.IgdbApi
         [JsonProperty("id")]
         public int Id { get; set; }
 
-        [IgdbEntityReferenceableValue]
         [JsonProperty("name", Required = Required.Always)]
         public string Name { get; set; }
+
+        public override string GetReferenceString(IIgdbCache cache)
+        {
+            return this.Name;
+        }
     }
 }

--- a/GlogGenerator/IgdbApi/IgdbTheme.cs
+++ b/GlogGenerator/IgdbApi/IgdbTheme.cs
@@ -10,8 +10,12 @@ namespace GlogGenerator.IgdbApi
         [JsonProperty("id")]
         public int Id { get; set; }
 
-        [IgdbEntityReferenceableValue]
         [JsonProperty("name", Required = Required.Always)]
         public string Name { get; set; }
+
+        public override string GetReferenceString(IIgdbCache cache)
+        {
+            return this.Name;
+        }
     }
 }

--- a/GlogGenerator/IgdbCache.cs
+++ b/GlogGenerator/IgdbCache.cs
@@ -311,13 +311,7 @@ namespace GlogGenerator
                 foreach (var releaseYear in gamesByReleaseYear.Keys)
                 {
                     var disambiguateByReleaseYear = false;
-
-                    // If multiple games with this name were released in the SAME year, then they need to be disambiguated by their release platforms.
-                    // TODO...!
-                    if (gamesByReleaseYear[releaseYear].Count() > 1)
-                    {
-                        throw new InvalidDataException($"Multiple games have the same display name \"{duplicatedName}\" as well as the same release year {releaseYear}.");
-                    }
+                    var disambiguateByPlatforms = false;
 
                     // If this release year isn't the earliest year for a game of this name, later-released games will be disambiguated by release year.
                     if (releaseYear != earliestReleaseYear)
@@ -325,9 +319,23 @@ namespace GlogGenerator
                         disambiguateByReleaseYear = true;
                     }
 
+                    // If multiple games with this name were released in the SAME year, then they need to be disambiguated by their release platforms.
+                    if (gamesByReleaseYear[releaseYear].Count() > 1)
+                    {
+                        disambiguateByPlatforms = true;
+                    }
+
                     foreach (var game in gamesByReleaseYear[releaseYear])
                     {
-                        gamesCurrentById[game.Id].NameGlogAppendReleaseYear = disambiguateByReleaseYear;
+                        if (disambiguateByPlatforms)
+                        {
+                            gamesCurrentById[game.Id].NameGlogAppendPlatforms = true;
+                        }
+
+                        if (disambiguateByReleaseYear)
+                        {
+                            gamesCurrentById[game.Id].NameGlogAppendReleaseYear = true;
+                        }
                     }
                 }
             }

--- a/GlogGenerator/IgdbCache.cs
+++ b/GlogGenerator/IgdbCache.cs
@@ -261,13 +261,13 @@ namespace GlogGenerator
 #endif
             this.keywordsById = keywordsCurrent.ToDictionary(o => o.Id, o => o);
 
-            var platformIds = this.platformsById.Keys.ToList();
+            var platformIds = gamesCurrent.SelectMany(g => g.PlatformIds).Distinct().ToList();
             var platformsCurrent = await client.GetPlatformsAsync(platformIds);
 
             var platformsCurrentById = platformsCurrent.ToDictionary(o => o.Id, o => o);
 
             // Re-apply overridden properties from the old cache.
-            foreach (var platformId in platformIds)
+            foreach (var platformId in this.platformsById.Keys)
             {
                 if (platformsCurrentById.ContainsKey(platformId))
                 {

--- a/content/post/migrated-from-wordpress/2009/07/2089.md
+++ b/content/post/migrated-from-wordpress/2009/07/2089.md
@@ -3,7 +3,7 @@ date = "2009-07-16T00:09:06-07:00"
 title = "Ghostbusters: The Video Game"
 slug = "ghostbusters-the-video-game-4"
 category = [ "Playing A Game" ]
-game = [ "Ghostbusters: The Video Game" ]
+game = [ "Ghostbusters: The Video Game (PS2, PSP, Wii)" ]
 platform = [ "Wii" ]
 rating = [ "Meh" ]
 +++

--- a/content/post/migrated-from-wordpress/2009/07/2306.md
+++ b/content/post/migrated-from-wordpress/2009/07/2306.md
@@ -3,7 +3,7 @@ date = "2009-07-23T07:11:17-07:00"
 title = "Ghostbusters: The Video Game"
 slug = "ghostbusters-the-video-game-5"
 category = [ "Playing A Game" ]
-game = [ "Ghostbusters: The Video Game" ]
+game = [ "Ghostbusters: The Video Game (PS2, PSP, Wii)" ]
 platform = [ "Wii" ]
 rating = [ "Meh" ]
 +++

--- a/content/post/migrated-from-wordpress/2009/07/2643.md
+++ b/content/post/migrated-from-wordpress/2009/07/2643.md
@@ -3,7 +3,7 @@ date = "2009-07-18T18:26:11-07:00"
 title = "Ghostbusters: The Video Game"
 slug = "ghostbusters-the-video-game-6"
 category = [ "Playing A Game" ]
-game = [ "Ghostbusters: The Video Game" ]
+game = [ "Ghostbusters: The Video Game (PC, PS3, X360)" ]
 platform = [ "X360" ]
 rating = [ "Meh" ]
 +++

--- a/content/post/migrated-from-wordpress/2010/12/2976.md
+++ b/content/post/migrated-from-wordpress/2010/12/2976.md
@@ -20,7 +20,7 @@ As for the, uh, <i>transforming</i> aspect of the game, there's an Autobot count
 
 If you're in love with the Transformers franchise, you'll love this game; and if you just like robots shooting at each other, there's some fun in here too.  But as the game marches on, sloppiness and general mediocrity bring the experience down.  Other than the impressive visuals, and the fact that it doesn't suck, there's nothing really remarkable here.
 
-<b>Better than</b>: <game:Ghostbusters: The Video Game>  
+<b>Better than</b>: <game:Ghostbusters: The Video Game (PC, PS3, X360)>  
 <b>Not as good as</b>: <game:Vanquish>  
 <b>Oh, yeah</b>: if you care about online multiplayer, I've read that this one is <a href="http://www.destructoid.com/review-transformers-war-for-cybertron-177164.phtml">pretty good</a>
 

--- a/igdb_cache.json
+++ b/igdb_cache.json
@@ -1013,6 +1013,10 @@
       "name": "DriveClub"
     },
     {
+      "id": 1854,
+      "name": "Ghostbusters"
+    },
+    {
       "id": 1883,
       "name": "Retro City Rampage"
     },
@@ -2701,6 +2705,10 @@
     {
       "id": 390,
       "name": "THQ Wireless"
+    },
+    {
+      "id": 391,
+      "name": "Red Fly Studio"
     },
     {
       "id": 392,
@@ -27383,6 +27391,7 @@
         13076
       ],
       "name": "Ghostbusters: The Video Game",
+      "name_glogAppendPlatforms": true,
       "parent_game": -1,
       "platforms": [
         6,
@@ -128297,6 +128306,52 @@
     },
     {
       "bundles": [],
+      "category": 11,
+      "collection": -1,
+      "collections": [
+        1854
+      ],
+      "dlcs": [],
+      "expanded_games": [],
+      "expansions": [],
+      "first_release_date": 1245110400,
+      "forks": [],
+      "franchise": -1,
+      "franchises": [],
+      "game_modes": [],
+      "genres": [],
+      "id": 77275,
+      "involved_companies": [
+        78737
+      ],
+      "keywords": [
+        4142
+      ],
+      "name": "Ghostbusters: The Video Game",
+      "name_glogAppendPlatforms": true,
+      "parent_game": 566,
+      "platforms": [
+        20
+      ],
+      "player_perspectives": [],
+      "ports": [],
+      "release_dates": [
+        139828,
+        139829
+      ],
+      "remakes": [],
+      "remasters": [],
+      "standalone_expansions": [],
+      "themes": [
+        1,
+        18,
+        27
+      ],
+      "url": "https://www.igdb.com/games/ghostbusters-the-video-game--1",
+      "version_parent": -1
+    },
+    {
+      "bundles": [],
       "category": 0,
       "collection": -1,
       "collections": [
@@ -137685,6 +137740,69 @@
       "version_parent": -1
     },
     {
+      "bundles": [],
+      "category": 11,
+      "collection": -1,
+      "collections": [],
+      "dlcs": [],
+      "expanded_games": [],
+      "expansions": [],
+      "first_release_date": 1245110400,
+      "forks": [],
+      "franchise": -1,
+      "franchises": [
+        8
+      ],
+      "game_modes": [
+        1
+      ],
+      "genres": [
+        5,
+        31
+      ],
+      "id": 210296,
+      "involved_companies": [
+        179864,
+        179865,
+        185856
+      ],
+      "keywords": [],
+      "name": "Ghostbusters: The Video Game",
+      "name_glogAppendPlatforms": true,
+      "parent_game": 566,
+      "platforms": [
+        5,
+        8,
+        38
+      ],
+      "player_perspectives": [
+        2
+      ],
+      "ports": [],
+      "release_dates": [
+        374972,
+        374973,
+        374974,
+        374975,
+        374976,
+        374977,
+        374978,
+        374979,
+        374980
+      ],
+      "remakes": [],
+      "remasters": [],
+      "standalone_expansions": [],
+      "themes": [
+        1,
+        18,
+        19,
+        27
+      ],
+      "url": "https://www.igdb.com/games/ghostbusters-the-video-game--2",
+      "version_parent": -1
+    },
+    {
       "bundles": [
         277807
       ],
@@ -145687,6 +145805,10 @@
       "company": 16565
     },
     {
+      "id": 78737,
+      "company": 453
+    },
+    {
       "id": 78776,
       "company": 19967
     },
@@ -149475,6 +149597,14 @@
       "company": 835
     },
     {
+      "id": 179864,
+      "company": 2134
+    },
+    {
+      "id": 179865,
+      "company": 391
+    },
+    {
       "id": 179932,
       "company": 15527
     },
@@ -149928,6 +150058,10 @@
     },
     {
       "id": 185855,
+      "company": 13634
+    },
+    {
+      "id": 185856,
       "company": 13634
     },
     {

--- a/igdb_cache.json
+++ b/igdb_cache.json
@@ -4359,6 +4359,10 @@
       "name": "Mediatonic"
     },
     {
+      "id": 2582,
+      "name": "SNK Playmore"
+    },
+    {
       "id": 2603,
       "name": "Free Lives Games"
     },
@@ -7939,6 +7943,7 @@
       "keywords": [],
       "name": "Everybody Votes Channel",
       "parent_game": -1,
+      "platforms": [],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [],
@@ -7967,6 +7972,7 @@
       "keywords": [],
       "name": "Internet Channel",
       "parent_game": -1,
+      "platforms": [],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [],
@@ -7995,6 +8001,7 @@
       "keywords": [],
       "name": "Nintendo Channel",
       "parent_game": -1,
+      "platforms": [],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [],
@@ -8023,6 +8030,7 @@
       "keywords": [],
       "name": "Nintendo DS Browser",
       "parent_game": -1,
+      "platforms": [],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [],
@@ -8051,6 +8059,7 @@
       "keywords": [],
       "name": "Pirate Battle",
       "parent_game": -1,
+      "platforms": [],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [],
@@ -8079,6 +8088,7 @@
       "keywords": [],
       "name": "Regex Crossword",
       "parent_game": -1,
+      "platforms": [],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [],
@@ -8161,6 +8171,9 @@
       ],
       "name": "Thief: The Dark Project",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [
         1
       ],
@@ -8261,6 +8274,14 @@
       ],
       "name": "Thief",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        14,
+        48,
+        49
+      ],
       "player_perspectives": [
         1
       ],
@@ -8331,6 +8352,12 @@
       "keywords": [],
       "name": "Baldur's Gate",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        39
+      ],
       "player_perspectives": [
         3
       ],
@@ -8478,6 +8505,9 @@
       ],
       "name": "Vampire: The Masquerade - Bloodlines",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [
         1,
         2
@@ -8644,6 +8674,13 @@
       ],
       "name": "Fallout: A Post Nuclear Role Playing Game",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        13,
+        14,
+        113
+      ],
       "player_perspectives": [
         3
       ],
@@ -8993,6 +9030,11 @@
       ],
       "name": "Fallout 3",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         1,
         2
@@ -9238,6 +9280,11 @@
       ],
       "name": "Fallout: New Vegas",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         1,
         2
@@ -9536,6 +9583,11 @@
       ],
       "name": "BioShock",
       "parent_game": -1,
+      "platforms": [
+        6,
+        12,
+        14
+      ],
       "player_perspectives": [
         1
       ],
@@ -9795,6 +9847,12 @@
       ],
       "name": "BioShock 2",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        14
+      ],
       "player_perspectives": [
         1
       ],
@@ -9888,6 +9946,11 @@
       ],
       "name": "System Shock",
       "parent_game": -1,
+      "platforms": [
+        13,
+        14,
+        149
+      ],
       "player_perspectives": [
         1
       ],
@@ -10098,6 +10161,11 @@
       ],
       "name": "Mafia II",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -10281,6 +10349,11 @@
       ],
       "name": "Deus Ex",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         1
       ],
@@ -10478,6 +10551,12 @@
       ],
       "name": "Deus Ex: Human Revolution",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        14
+      ],
       "player_perspectives": [
         1
       ],
@@ -10591,6 +10670,11 @@
       ],
       "name": "Overlord",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -10650,6 +10734,11 @@
       ],
       "name": "Overlord: Raising Hell",
       "parent_game": 44,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -10742,6 +10831,11 @@
       ],
       "name": "Overlord II",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -10802,6 +10896,9 @@
       ],
       "name": "Overlord: Dark Legend",
       "parent_game": -1,
+      "platforms": [
+        5
+      ],
       "player_perspectives": [
         2
       ],
@@ -10856,6 +10953,9 @@
       ],
       "name": "Overlord: Minions",
       "parent_game": -1,
+      "platforms": [
+        20
+      ],
       "player_perspectives": [
         3
       ],
@@ -11151,6 +11251,11 @@
       ],
       "name": "The Elder Scrolls IV: Oblivion",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         1,
         2
@@ -11222,6 +11327,13 @@
       ],
       "name": "Tales of Monkey Island",
       "parent_game": -1,
+      "platforms": [
+        5,
+        6,
+        9,
+        14,
+        39
+      ],
       "player_perspectives": [
         4
       ],
@@ -11280,6 +11392,13 @@
       ],
       "name": "The Secret of Monkey Island: Special Edition",
       "parent_game": 60,
+      "platforms": [
+        6,
+        9,
+        12,
+        14,
+        39
+      ],
       "player_perspectives": [
         4
       ],
@@ -11336,6 +11455,12 @@
       ],
       "name": "Monkey Island 2 Special Edition: LeChuck's Revenge",
       "parent_game": 61,
+      "platforms": [
+        6,
+        9,
+        12,
+        39
+      ],
       "player_perspectives": [
         4
       ],
@@ -11475,6 +11600,15 @@
       ],
       "name": "Portal",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        9,
+        12,
+        14,
+        34,
+        130
+      ],
       "player_perspectives": [
         1
       ],
@@ -11577,6 +11711,14 @@
       ],
       "name": "Portal 2",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        9,
+        12,
+        14,
+        130
+      ],
       "player_perspectives": [
         1
       ],
@@ -11664,6 +11806,11 @@
       ],
       "name": "Mass Effect",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -11945,6 +12092,11 @@
       ],
       "name": "Mass Effect 2",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -12055,6 +12207,12 @@
       ],
       "name": "Mass Effect 3",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        41
+      ],
       "player_perspectives": [
         2
       ],
@@ -12157,6 +12315,12 @@
       ],
       "name": "Dragon Age: Origins",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        14
+      ],
       "player_perspectives": [
         2,
         3
@@ -12323,6 +12487,12 @@
       ],
       "name": "L.A. Noire",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        163
+      ],
       "player_perspectives": [
         2
       ],
@@ -12417,6 +12587,14 @@
       ],
       "name": "Amnesia: The Dark Descent",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         1
       ],
@@ -12574,6 +12752,12 @@
       ],
       "name": "Assassin's Creed Brotherhood",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        14
+      ],
       "player_perspectives": [
         2
       ],
@@ -12667,6 +12851,10 @@
       ],
       "name": "Star Wars: The Old Republic",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14
+      ],
       "player_perspectives": [
         2
       ],
@@ -12738,6 +12926,10 @@
       ],
       "name": "League of Legends",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14
+      ],
       "player_perspectives": [
         3
       ],
@@ -12905,6 +13097,14 @@
       ],
       "name": "Star Wars: Knights of the Old Republic",
       "parent_game": -1,
+      "platforms": [
+        6,
+        11,
+        14,
+        34,
+        39,
+        130
+      ],
       "player_perspectives": [
         2
       ],
@@ -12992,6 +13192,9 @@
       ],
       "name": "The Last Guardian",
       "parent_game": -1,
+      "platforms": [
+        48
+      ],
       "player_perspectives": [
         2
       ],
@@ -13145,6 +13348,14 @@
       ],
       "name": "Star Wars: Knights of the Old Republic II - The Sith Lords",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        11,
+        14,
+        39,
+        130
+      ],
       "player_perspectives": [
         1,
         2
@@ -13253,6 +13464,14 @@
       ],
       "name": "Diablo III",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        14,
+        48,
+        49
+      ],
       "player_perspectives": [
         3
       ],
@@ -13423,6 +13642,11 @@
       ],
       "name": "Minecraft: Java Edition",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         1,
         2,
@@ -13566,6 +13790,10 @@
       ],
       "name": "World of Warcraft",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14
+      ],
       "player_perspectives": [
         2
       ],
@@ -13705,6 +13933,11 @@
       ],
       "name": "Diablo",
       "parent_game": -1,
+      "platforms": [
+        6,
+        7,
+        14
+      ],
       "player_perspectives": [
         3
       ],
@@ -13777,6 +14010,10 @@
       ],
       "name": "Diablo II",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14
+      ],
       "player_perspectives": [
         3
       ],
@@ -14004,6 +14241,13 @@
       ],
       "name": "Assassin's Creed II",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        14,
+        39
+      ],
       "player_perspectives": [
         2
       ],
@@ -14111,6 +14355,10 @@
       ],
       "name": "Assassin's Creed",
       "parent_game": -1,
+      "platforms": [
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -14190,6 +14438,10 @@
       ],
       "name": "Warcraft III: Reign of Chaos",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14
+      ],
       "player_perspectives": [
         3
       ],
@@ -14254,6 +14506,9 @@
       ],
       "name": "Devil May Cry",
       "parent_game": -1,
+      "platforms": [
+        8
+      ],
       "player_perspectives": [
         2
       ],
@@ -14358,6 +14613,9 @@
       ],
       "name": "Devil May Cry 2",
       "parent_game": -1,
+      "platforms": [
+        8
+      ],
       "player_perspectives": [
         2
       ],
@@ -14483,6 +14741,9 @@
       ],
       "name": "Devil May Cry 3: Dante's Awakening",
       "parent_game": -1,
+      "platforms": [
+        8
+      ],
       "player_perspectives": [
         2
       ],
@@ -14587,6 +14848,12 @@
       ],
       "name": "Star Wars: Republic Commando",
       "parent_game": -1,
+      "platforms": [
+        6,
+        11,
+        48,
+        130
+      ],
       "player_perspectives": [
         1
       ],
@@ -14706,6 +14973,14 @@
       ],
       "name": "Star Wars: Jedi Knight II - Jedi Outcast",
       "parent_game": -1,
+      "platforms": [
+        6,
+        11,
+        14,
+        21,
+        48,
+        130
+      ],
       "player_perspectives": [
         1,
         2
@@ -14775,6 +15050,10 @@
       ],
       "name": "Star Wars: Episode I - Battle for Naboo",
       "parent_game": -1,
+      "platforms": [
+        4,
+        6
+      ],
       "player_perspectives": [
         2
       ],
@@ -14864,6 +15143,10 @@
       ],
       "name": "Star Wars: Rogue Squadron",
       "parent_game": -1,
+      "platforms": [
+        4,
+        6
+      ],
       "player_perspectives": [
         2
       ],
@@ -14943,6 +15226,10 @@
       ],
       "name": "Star Wars: TIE Fighter",
       "parent_game": -1,
+      "platforms": [
+        13,
+        14
+      ],
       "player_perspectives": [
         1
       ],
@@ -15009,6 +15296,10 @@
       ],
       "name": "Star Wars: X-Wing",
       "parent_game": -1,
+      "platforms": [
+        13,
+        14
+      ],
       "player_perspectives": [
         1
       ],
@@ -15095,6 +15386,15 @@
       ],
       "name": "Maniac Mansion",
       "parent_game": -1,
+      "platforms": [
+        6,
+        13,
+        14,
+        15,
+        16,
+        63,
+        75
+      ],
       "player_perspectives": [
         4
       ],
@@ -15214,6 +15514,12 @@
       ],
       "name": "Sam & Max Hit the Road",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        13,
+        14
+      ],
       "player_perspectives": [
         4
       ],
@@ -15378,6 +15684,13 @@
       ],
       "name": "Brütal Legend",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        9,
+        12,
+        14
+      ],
       "player_perspectives": [
         2
       ],
@@ -15503,6 +15816,10 @@
       ],
       "name": "Warhammer Online: Age of Reckoning",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14
+      ],
       "player_perspectives": [
         1,
         2
@@ -15590,6 +15907,12 @@
       ],
       "name": "MDK2",
       "parent_game": -1,
+      "platforms": [
+        5,
+        6,
+        8,
+        23
+      ],
       "player_perspectives": [
         2
       ],
@@ -15668,6 +15991,12 @@
       ],
       "name": "MDK",
       "parent_game": -1,
+      "platforms": [
+        6,
+        7,
+        13,
+        14
+      ],
       "player_perspectives": [
         2
       ],
@@ -15784,6 +16113,11 @@
       ],
       "name": "The Sims",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         3
       ],
@@ -16002,6 +16336,10 @@
       ],
       "name": "World of Warcraft: The Burning Crusade",
       "parent_game": 123,
+      "platforms": [
+        6,
+        14
+      ],
       "player_perspectives": [
         2
       ],
@@ -16064,6 +16402,10 @@
       ],
       "name": "World of Warcraft: Wrath of the Lich King",
       "parent_game": 123,
+      "platforms": [
+        6,
+        14
+      ],
       "player_perspectives": [
         2
       ],
@@ -16204,6 +16546,10 @@
       ],
       "name": "World of Warcraft: Cataclysm",
       "parent_game": 123,
+      "platforms": [
+        6,
+        14
+      ],
       "player_perspectives": [
         2
       ],
@@ -16354,6 +16700,10 @@
       ],
       "name": "StarCraft",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14
+      ],
       "player_perspectives": [
         3
       ],
@@ -16498,6 +16848,12 @@
       ],
       "name": "Half-Life",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        8,
+        14
+      ],
       "player_perspectives": [
         1
       ],
@@ -16596,6 +16952,15 @@
       ],
       "name": "Half-Life 2",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        9,
+        11,
+        12,
+        14,
+        34
+      ],
       "player_perspectives": [
         1
       ],
@@ -16671,6 +17036,21 @@
       "keywords": [],
       "name": "Myst",
       "parent_game": -1,
+      "platforms": [
+        6,
+        7,
+        14,
+        16,
+        32,
+        37,
+        38,
+        39,
+        50,
+        74,
+        117,
+        410,
+        487
+      ],
       "player_perspectives": [
         1
       ],
@@ -16756,6 +17136,10 @@
       ],
       "name": "StarCraft II: Wings of Liberty",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14
+      ],
       "player_perspectives": [
         3
       ],
@@ -16879,6 +17263,10 @@
       ],
       "name": "Battlefield 1942",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14
+      ],
       "player_perspectives": [
         1,
         2
@@ -17007,6 +17395,12 @@
       ],
       "name": "Counter-Strike",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        11,
+        14
+      ],
       "player_perspectives": [
         1
       ],
@@ -17122,6 +17516,12 @@
       ],
       "name": "The Bureau: XCOM Declassified",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        14
+      ],
       "player_perspectives": [
         1
       ],
@@ -17266,6 +17666,10 @@
       ],
       "name": "Diablo II: Lord of Destruction",
       "parent_game": 126,
+      "platforms": [
+        6,
+        14
+      ],
       "player_perspectives": [
         3
       ],
@@ -17328,6 +17732,13 @@
       ],
       "name": "Unreal Tournament",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        8,
+        14,
+        23
+      ],
       "player_perspectives": [
         1
       ],
@@ -17419,6 +17830,13 @@
       ],
       "name": "Command & Conquer: Red Alert",
       "parent_game": -1,
+      "platforms": [
+        6,
+        7,
+        9,
+        13,
+        38
+      ],
       "player_perspectives": [
         3
       ],
@@ -17514,6 +17932,12 @@
       ],
       "name": "American McGee's Alice",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        14
+      ],
       "player_perspectives": [
         2
       ],
@@ -17722,6 +18146,11 @@
       ],
       "name": "Battlefield 3",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         1,
         2,
@@ -17912,6 +18341,16 @@
       ],
       "name": "Super Mario Bros.",
       "parent_game": -1,
+      "platforms": [
+        5,
+        18,
+        37,
+        41,
+        51,
+        52,
+        99,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -18052,6 +18491,11 @@
       ],
       "name": "Heroes of Might and Magic III: The Restoration of Erathia",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         3
       ],
@@ -18176,6 +18620,10 @@
       ],
       "name": "Metal Gear",
       "parent_game": -1,
+      "platforms": [
+        5,
+        53
+      ],
       "player_perspectives": [
         3
       ],
@@ -18236,6 +18684,9 @@
       ],
       "name": "Metal Gear Solid 2: Sons of Liberty",
       "parent_game": -1,
+      "platforms": [
+        8
+      ],
       "player_perspectives": [
         2
       ],
@@ -18393,6 +18844,12 @@
       ],
       "name": "Metal Gear Rising: Revengeance",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        14
+      ],
       "player_perspectives": [
         2
       ],
@@ -18661,6 +19118,9 @@
       ],
       "name": "Metal Gear Solid 3: Snake Eater",
       "parent_game": -1,
+      "platforms": [
+        8
+      ],
       "player_perspectives": [
         1,
         2,
@@ -18807,6 +19267,12 @@
       ],
       "name": "Final Fantasy XIII-2",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        49
+      ],
       "player_perspectives": [
         2
       ],
@@ -18881,6 +19347,13 @@
       ],
       "name": "Final Fantasy",
       "parent_game": -1,
+      "platforms": [
+        5,
+        18,
+        37,
+        41,
+        99
+      ],
       "player_perspectives": [
         3,
         4
@@ -18985,6 +19458,11 @@
       ],
       "name": "Final Fantasy XIII",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2,
         3
@@ -19179,6 +19657,9 @@
       ],
       "name": "Final Fantasy XII",
       "parent_game": -1,
+      "platforms": [
+        8
+      ],
       "player_perspectives": [
         2
       ],
@@ -19287,6 +19768,12 @@
       ],
       "name": "Final Fantasy IV",
       "parent_game": 16587,
+      "platforms": [
+        6,
+        20,
+        34,
+        39
+      ],
       "player_perspectives": [
         2
       ],
@@ -19451,6 +19938,11 @@
       ],
       "name": "Final Fantasy XI Online",
       "parent_game": -1,
+      "platforms": [
+        6,
+        8,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -19580,6 +20072,9 @@
       ],
       "name": "Final Fantasy: Crystal Chronicles",
       "parent_game": -1,
+      "platforms": [
+        21
+      ],
       "player_perspectives": [
         3,
         4
@@ -19742,6 +20237,9 @@
       ],
       "name": "Final Fantasy X-2",
       "parent_game": -1,
+      "platforms": [
+        8
+      ],
       "player_perspectives": [
         2,
         4
@@ -19857,6 +20355,10 @@
       ],
       "name": "Final Fantasy Tactics Advance",
       "parent_game": -1,
+      "platforms": [
+        24,
+        41
+      ],
       "player_perspectives": [
         3
       ],
@@ -19952,6 +20454,9 @@
       ],
       "name": "Final Fantasy X",
       "parent_game": -1,
+      "platforms": [
+        8
+      ],
       "player_perspectives": [
         2,
         3,
@@ -20032,6 +20537,10 @@
       ],
       "name": "Final Fantasy V",
       "parent_game": -1,
+      "platforms": [
+        5,
+        58
+      ],
       "player_perspectives": [
         3,
         4
@@ -20101,6 +20610,9 @@
       ],
       "name": "Final Fantasy Chronicles",
       "parent_game": -1,
+      "platforms": [
+        7
+      ],
       "player_perspectives": [
         3,
         4
@@ -20296,6 +20808,12 @@
       ],
       "name": "Final Fantasy IX",
       "parent_game": -1,
+      "platforms": [
+        7,
+        9,
+        38,
+        46
+      ],
       "player_perspectives": [
         2,
         3
@@ -20404,6 +20922,9 @@
       ],
       "name": "Final Fantasy Anthology",
       "parent_game": -1,
+      "platforms": [
+        7
+      ],
       "player_perspectives": [
         3,
         4
@@ -20553,6 +21074,10 @@
       ],
       "name": "Resident Evil",
       "parent_game": -1,
+      "platforms": [
+        6,
+        7
+      ],
       "player_perspectives": [
         2
       ],
@@ -20782,6 +21307,12 @@
       ],
       "name": "Final Fantasy VIII",
       "parent_game": -1,
+      "platforms": [
+        7,
+        9,
+        38,
+        46
+      ],
       "player_perspectives": [
         2,
         3
@@ -21019,6 +21550,12 @@
       ],
       "name": "Final Fantasy VI",
       "parent_game": -1,
+      "platforms": [
+        5,
+        41,
+        58,
+        137
+      ],
       "player_perspectives": [
         3,
         4
@@ -21172,6 +21709,12 @@
       ],
       "name": "Final Fantasy VII",
       "parent_game": -1,
+      "platforms": [
+        7,
+        9,
+        38,
+        46
+      ],
       "player_perspectives": [
         2,
         3
@@ -21326,6 +21869,10 @@
       ],
       "name": "Final Fantasy Tactics",
       "parent_game": -1,
+      "platforms": [
+        7,
+        9
+      ],
       "player_perspectives": [
         3
       ],
@@ -21396,6 +21943,9 @@
       ],
       "name": "Uncharted: Drake's Fortune",
       "parent_game": -1,
+      "platforms": [
+        9
+      ],
       "player_perspectives": [
         2
       ],
@@ -21614,6 +22164,10 @@
       ],
       "name": "Red Dead Redemption",
       "parent_game": -1,
+      "platforms": [
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -21689,6 +22243,10 @@
       ],
       "name": "The Lost Vikings",
       "parent_game": -1,
+      "platforms": [
+        19,
+        58
+      ],
       "player_perspectives": [
         4
       ],
@@ -21801,6 +22359,10 @@
       ],
       "name": "StarCraft: Brood War",
       "parent_game": 230,
+      "platforms": [
+        6,
+        14
+      ],
       "player_perspectives": [
         3
       ],
@@ -21855,6 +22417,10 @@
       ],
       "name": "StarCraft II: Heart of the Swarm",
       "parent_game": 239,
+      "platforms": [
+        6,
+        14
+      ],
       "player_perspectives": [
         3
       ],
@@ -21954,6 +22520,10 @@
       ],
       "name": "StarCraft II: Legacy of the Void",
       "parent_game": 239,
+      "platforms": [
+        6,
+        14
+      ],
       "player_perspectives": [
         3
       ],
@@ -22164,6 +22734,11 @@
       ],
       "name": "The Elder Scrolls V: Skyrim",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         1,
         2
@@ -22294,6 +22869,18 @@
       ],
       "name": "Star Wars: The Force Unleashed",
       "parent_game": -1,
+      "platforms": [
+        5,
+        6,
+        8,
+        9,
+        12,
+        14,
+        38,
+        39,
+        42,
+        130
+      ],
       "player_perspectives": [
         2
       ],
@@ -22409,6 +22996,12 @@
       ],
       "name": "The Witcher 2: Assassins of Kings",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        12,
+        14
+      ],
       "player_perspectives": [
         2
       ],
@@ -22500,6 +23093,12 @@
       ],
       "name": "Duke Nukem Forever",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        14
+      ],
       "player_perspectives": [
         1
       ],
@@ -22579,6 +23178,11 @@
       ],
       "name": "Castlevania: Lords of Shadow",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -22740,6 +23344,10 @@
       ],
       "name": "Gears of War 3",
       "parent_game": -1,
+      "platforms": [
+        12,
+        49
+      ],
       "player_perspectives": [
         2
       ],
@@ -22853,6 +23461,11 @@
       ],
       "name": "Bulletstorm",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         1
       ],
@@ -23015,6 +23628,14 @@
       ],
       "name": "Dead Rising 2",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        9,
+        12,
+        48,
+        49
+      ],
       "player_perspectives": [
         2
       ],
@@ -23113,6 +23734,10 @@
       ],
       "name": "Resident Evil: The Darkside Chronicles",
       "parent_game": -1,
+      "platforms": [
+        5,
+        9
+      ],
       "player_perspectives": [
         1
       ],
@@ -23203,6 +23828,14 @@
       ],
       "name": "Borderlands",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        14,
+        49,
+        130
+      ],
       "player_perspectives": [
         1
       ],
@@ -23392,6 +24025,9 @@
       ],
       "name": "God of War III",
       "parent_game": -1,
+      "platforms": [
+        9
+      ],
       "player_perspectives": [
         2
       ],
@@ -23480,6 +24116,14 @@
       ],
       "name": "Batman: Arkham Asylum",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        14,
+        72,
+        130
+      ],
       "player_perspectives": [
         2
       ],
@@ -23597,6 +24241,13 @@
       ],
       "name": "Batman: Arkham City",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        113,
+        130
+      ],
       "player_perspectives": [
         2
       ],
@@ -23736,6 +24387,11 @@
       ],
       "name": "Sonic Generations",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2,
         4
@@ -23822,6 +24478,9 @@
       ],
       "name": "Uncharted 3: Drake's Deception",
       "parent_game": -1,
+      "platforms": [
+        9
+      ],
       "player_perspectives": [
         2
       ],
@@ -23932,6 +24591,11 @@
       ],
       "name": "Red Faction: Armageddon",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -24091,6 +24755,11 @@
       ],
       "name": "Far Cry 3",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         1
       ],
@@ -24171,6 +24840,12 @@
       ],
       "name": "Hitman: Absolution",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        14
+      ],
       "player_perspectives": [
         2
       ],
@@ -24380,6 +25055,11 @@
       ],
       "name": "Dishonored",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         1
       ],
@@ -24489,6 +25169,10 @@
       ],
       "name": "The Legend of Zelda: Skyward Sword",
       "parent_game": -1,
+      "platforms": [
+        5,
+        41
+      ],
       "player_perspectives": [
         2
       ],
@@ -24564,6 +25248,9 @@
       ],
       "name": "WildStar",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [
         2
       ],
@@ -24648,6 +25335,11 @@
       ],
       "name": "Dead Island",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         1
       ],
@@ -24756,6 +25448,11 @@
       ],
       "name": "Assassin's Creed Revelations",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -25007,6 +25704,13 @@
       ],
       "name": "BioShock Infinite",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        9,
+        12,
+        14
+      ],
       "player_perspectives": [
         1
       ],
@@ -25122,6 +25826,11 @@
       ],
       "name": "Call of Juarez: The Cartel",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         1
       ],
@@ -25259,6 +25968,11 @@
       ],
       "name": "The Darkness II",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         1
       ],
@@ -25376,6 +26090,9 @@
       ],
       "name": "Gears of War",
       "parent_game": -1,
+      "platforms": [
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -25578,6 +26295,9 @@
       ],
       "name": "Gears of War 2",
       "parent_game": -1,
+      "platforms": [
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -25748,6 +26468,9 @@
       ],
       "name": "God of War",
       "parent_game": -1,
+      "platforms": [
+        8
+      ],
       "player_perspectives": [
         2
       ],
@@ -25899,6 +26622,9 @@
       ],
       "name": "God of War II",
       "parent_game": -1,
+      "platforms": [
+        8
+      ],
       "player_perspectives": [
         2
       ],
@@ -25982,6 +26708,11 @@
       ],
       "name": "Transformers: War for Cybertron",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -26142,6 +26873,12 @@
       ],
       "name": "Just Cause 2",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -26251,6 +26988,12 @@
       ],
       "name": "Call of Duty: Modern Warfare 2",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        14
+      ],
       "player_perspectives": [
         1
       ],
@@ -26322,6 +27065,14 @@
       ],
       "name": "Tom Clancy's Splinter Cell: Conviction",
       "parent_game": -1,
+      "platforms": [
+        6,
+        12,
+        14,
+        34,
+        39,
+        49
+      ],
       "player_perspectives": [
         2
       ],
@@ -26429,6 +27180,11 @@
       ],
       "name": "Rogue Warrior",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         1,
         2
@@ -26523,6 +27279,9 @@
       ],
       "name": "Uncharted 2: Among Thieves",
       "parent_game": -1,
+      "platforms": [
+        9
+      ],
       "player_perspectives": [
         2
       ],
@@ -26625,6 +27384,11 @@
       ],
       "name": "Ghostbusters: The Video Game",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -26786,6 +27550,11 @@
       ],
       "name": "Wolfenstein",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         1
       ],
@@ -26923,6 +27692,13 @@
       ],
       "name": "Prototype",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        48,
+        49
+      ],
       "player_perspectives": [
         2
       ],
@@ -27013,6 +27789,10 @@
       ],
       "name": "Eat Lead: The Return of Matt Hazard",
       "parent_game": -1,
+      "platforms": [
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -27125,6 +27905,11 @@
       ],
       "name": "Warhammer 40,000: Space Marine",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -27275,6 +28060,11 @@
       ],
       "name": "Burnout Paradise",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         1,
         2
@@ -27539,6 +28329,12 @@
       ],
       "name": "Call of Duty 4: Modern Warfare",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        14
+      ],
       "player_perspectives": [
         1
       ],
@@ -27656,6 +28452,14 @@
       ],
       "name": "Command & Conquer",
       "parent_game": -1,
+      "platforms": [
+        4,
+        6,
+        7,
+        13,
+        14,
+        32
+      ],
       "player_perspectives": [
         3
       ],
@@ -27769,6 +28573,10 @@
       ],
       "name": "Company of Heroes",
       "parent_game": -1,
+      "platforms": [
+        6,
+        39
+      ],
       "player_perspectives": [
         3
       ],
@@ -27871,6 +28679,13 @@
       ],
       "name": "Grand Theft Auto III",
       "parent_game": -1,
+      "platforms": [
+        6,
+        8,
+        11,
+        14,
+        48
+      ],
       "player_perspectives": [
         2,
         3
@@ -27990,6 +28805,11 @@
       ],
       "name": "Grand Theft Auto IV",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -28129,6 +28949,17 @@
       ],
       "name": "Grand Theft Auto: San Andreas",
       "parent_game": -1,
+      "platforms": [
+        6,
+        8,
+        9,
+        11,
+        12,
+        14,
+        34,
+        39,
+        48
+      ],
       "player_perspectives": [
         1,
         2
@@ -28281,6 +29112,12 @@
       ],
       "name": "Grand Theft Auto: Vice City",
       "parent_game": -1,
+      "platforms": [
+        6,
+        8,
+        11,
+        14
+      ],
       "player_perspectives": [
         2
       ],
@@ -28493,6 +29330,12 @@
       ],
       "name": "Halo: Combat Evolved",
       "parent_game": -1,
+      "platforms": [
+        6,
+        11,
+        12,
+        14
+      ],
       "player_perspectives": [
         1,
         2
@@ -28598,6 +29441,12 @@
       ],
       "name": "Hitman 2: Silent Assassin",
       "parent_game": -1,
+      "platforms": [
+        6,
+        8,
+        11,
+        21
+      ],
       "player_perspectives": [
         2
       ],
@@ -28670,6 +29519,11 @@
       ],
       "name": "Homeworld",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         3
       ],
@@ -28763,6 +29617,15 @@
       ],
       "name": "Lara Croft and the Guardian of Light",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        34,
+        39,
+        130,
+        170
+      ],
       "player_perspectives": [
         3
       ],
@@ -28862,6 +29725,13 @@
       ],
       "name": "Majesty: The Fantasy Kingdom Sim",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        34,
+        39
+      ],
       "player_perspectives": [
         3
       ],
@@ -28916,6 +29786,11 @@
       "keywords": [],
       "name": "Mass Effect 2: Lair of the Shadow Broker",
       "parent_game": 74,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -28969,6 +29844,11 @@
       ],
       "name": "Mass Effect 2: Overlord",
       "parent_game": 74,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -29034,6 +29914,9 @@
       ],
       "name": "Saints Row",
       "parent_game": -1,
+      "platforms": [
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -29250,6 +30133,11 @@
       ],
       "name": "Saints Row 2",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -29421,6 +30309,12 @@
       ],
       "name": "Planescape: Torment",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        39
+      ],
       "player_perspectives": [
         3
       ],
@@ -29552,6 +30446,13 @@
       ],
       "name": "Prince of Persia: The Sands of Time",
       "parent_game": -1,
+      "platforms": [
+        6,
+        8,
+        9,
+        11,
+        21
+      ],
       "player_perspectives": [
         2
       ],
@@ -29684,6 +30585,13 @@
       ],
       "name": "Prince of Persia: Warrior Within",
       "parent_game": -1,
+      "platforms": [
+        6,
+        8,
+        11,
+        21,
+        39
+      ],
       "player_perspectives": [
         2
       ],
@@ -29750,6 +30658,11 @@
       "keywords": [],
       "name": "Red Faction: Guerrilla",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -29963,6 +30876,11 @@
       ],
       "name": "Resident Evil 5",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -30068,6 +30986,10 @@
       ],
       "name": "Rise of Nations",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14
+      ],
       "player_perspectives": [
         3
       ],
@@ -30147,6 +31069,11 @@
       ],
       "name": "Sam & Max: Save the World",
       "parent_game": -1,
+      "platforms": [
+        5,
+        6,
+        12
+      ],
       "player_perspectives": [
         2,
         5
@@ -30239,6 +31166,11 @@
       ],
       "name": "Sid Meier's Alpha Centauri",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         3
       ],
@@ -30397,6 +31329,11 @@
       ],
       "name": "Sid Meier's Civilization V",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         3
       ],
@@ -30602,6 +31539,13 @@
       ],
       "name": "Saints Row: The Third",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        9,
+        12,
+        130
+      ],
       "player_perspectives": [
         2,
         4
@@ -30708,6 +31652,15 @@
       ],
       "name": "Resident Evil 2",
       "parent_game": -1,
+      "platforms": [
+        6,
+        7,
+        9,
+        21,
+        23,
+        38,
+        46
+      ],
       "player_perspectives": [
         2
       ],
@@ -30814,6 +31767,17 @@
       ],
       "name": "Super Meat Boy",
       "parent_game": -1,
+      "platforms": [
+        3,
+        5,
+        6,
+        12,
+        14,
+        41,
+        46,
+        48,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -30893,6 +31857,13 @@
       ],
       "name": "Team Fortress 2",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        9,
+        12,
+        14
+      ],
       "player_perspectives": [
         1
       ],
@@ -30989,6 +31960,16 @@
       ],
       "name": "World of Goo",
       "parent_game": -1,
+      "platforms": [
+        3,
+        5,
+        6,
+        14,
+        34,
+        39,
+        74,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -31153,6 +32134,12 @@
       ],
       "name": "Command & Conquer: Red Alert 3",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        14
+      ],
       "player_perspectives": [
         3
       ],
@@ -31326,6 +32313,12 @@
       ],
       "name": "Max Payne 3",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        14
+      ],
       "player_perspectives": [
         2
       ],
@@ -31392,6 +32385,9 @@
       ],
       "name": "Resident Evil Code: Veronica",
       "parent_game": -1,
+      "platforms": [
+        23
+      ],
       "player_perspectives": [
         2
       ],
@@ -31502,6 +32498,11 @@
       ],
       "name": "Resident Evil: The Umbrella Chronicles",
       "parent_game": -1,
+      "platforms": [
+        5,
+        9,
+        41
+      ],
       "player_perspectives": [
         1,
         2
@@ -31561,6 +32562,13 @@
       ],
       "name": "Tom Clancy's H.A.W.X",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        34,
+        39
+      ],
       "player_perspectives": [
         1
       ],
@@ -31660,6 +32668,10 @@
       ],
       "name": "Dead Space: Extraction",
       "parent_game": -1,
+      "platforms": [
+        5,
+        9
+      ],
       "player_perspectives": [
         1
       ],
@@ -31780,6 +32792,11 @@
       ],
       "name": "Halo 2",
       "parent_game": -1,
+      "platforms": [
+        6,
+        11,
+        49
+      ],
       "player_perspectives": [
         1
       ],
@@ -31902,6 +32919,11 @@
       ],
       "name": "Halo 3",
       "parent_game": -1,
+      "platforms": [
+        6,
+        12,
+        49
+      ],
       "player_perspectives": [
         1
       ],
@@ -32073,6 +33095,11 @@
       ],
       "name": "Halo 3: ODST",
       "parent_game": -1,
+      "platforms": [
+        6,
+        12,
+        49
+      ],
       "player_perspectives": [
         1
       ],
@@ -32186,6 +33213,11 @@
       ],
       "name": "Halo: Reach",
       "parent_game": -1,
+      "platforms": [
+        6,
+        12,
+        49
+      ],
       "player_perspectives": [
         1,
         2
@@ -32314,6 +33346,11 @@
       ],
       "name": "Halo 4",
       "parent_game": -1,
+      "platforms": [
+        6,
+        12,
+        49
+      ],
       "player_perspectives": [
         1,
         2
@@ -32409,6 +33446,12 @@
       ],
       "name": "Enter the Matrix",
       "parent_game": -1,
+      "platforms": [
+        6,
+        8,
+        11,
+        21
+      ],
       "player_perspectives": [
         2
       ],
@@ -32518,6 +33561,11 @@
       "name": "Syndicate",
       "name_glogAppendReleaseYear": true,
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         1
       ],
@@ -32687,6 +33735,9 @@
       ],
       "name": "The Last of Us",
       "parent_game": -1,
+      "platforms": [
+        9
+      ],
       "player_perspectives": [
         2
       ],
@@ -32787,6 +33838,18 @@
       ],
       "name": "Borderlands 2",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        9,
+        12,
+        14,
+        34,
+        46,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         1
       ],
@@ -32890,6 +33953,13 @@
       ],
       "name": "BloodRayne",
       "parent_game": -1,
+      "platforms": [
+        6,
+        8,
+        11,
+        14,
+        21
+      ],
       "player_perspectives": [
         2
       ],
@@ -32977,6 +34047,12 @@
       ],
       "name": "BloodRayne 2",
       "parent_game": -1,
+      "platforms": [
+        6,
+        8,
+        9,
+        11
+      ],
       "player_perspectives": [
         2
       ],
@@ -33250,6 +34326,13 @@
       ],
       "name": "Grand Theft Auto V",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        48,
+        49
+      ],
       "player_perspectives": [
         1,
         2
@@ -33344,6 +34427,14 @@
       ],
       "name": "The Legend of Zelda",
       "parent_game": -1,
+      "platforms": [
+        5,
+        18,
+        37,
+        41,
+        51,
+        99
+      ],
       "player_perspectives": [
         3
       ],
@@ -33418,6 +34509,11 @@
       ],
       "name": "Hacker Evolution",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         5
       ],
@@ -33475,6 +34571,11 @@
       ],
       "name": "Hacker Evolution: Untold",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         5
       ],
@@ -33591,6 +34692,13 @@
       ],
       "name": "Zelda II: The Adventure of Link",
       "parent_game": -1,
+      "platforms": [
+        5,
+        18,
+        37,
+        41,
+        51
+      ],
       "player_perspectives": [
         4
       ],
@@ -33777,6 +34885,14 @@
       ],
       "name": "The Legend of Zelda: A Link to the Past",
       "parent_game": -1,
+      "platforms": [
+        5,
+        19,
+        41,
+        58,
+        137,
+        306
+      ],
       "player_perspectives": [
         3
       ],
@@ -33899,6 +35015,9 @@
       ],
       "name": "The Legend of Zelda: Link's Awakening",
       "parent_game": -1,
+      "platforms": [
+        33
+      ],
       "player_perspectives": [
         3,
         4
@@ -34069,6 +35188,12 @@
       ],
       "name": "The Legend of Zelda: Ocarina of Time",
       "parent_game": -1,
+      "platforms": [
+        4,
+        5,
+        41,
+        416
+      ],
       "player_perspectives": [
         2
       ],
@@ -34178,6 +35303,12 @@
       ],
       "name": "The Legend of Zelda: Majora's Mask",
       "parent_game": -1,
+      "platforms": [
+        4,
+        5,
+        41,
+        416
+      ],
       "player_perspectives": [
         2
       ],
@@ -34260,6 +35391,9 @@
       ],
       "name": "The Legend of Zelda: The Wind Waker",
       "parent_game": -1,
+      "platforms": [
+        21
+      ],
       "player_perspectives": [
         2
       ],
@@ -34361,6 +35495,9 @@
       ],
       "name": "The Legend of Zelda: Four Swords Adventures",
       "parent_game": -1,
+      "platforms": [
+        21
+      ],
       "player_perspectives": [
         2,
         3
@@ -34524,6 +35661,11 @@
       ],
       "name": "The Legend of Zelda: The Minish Cap",
       "parent_game": -1,
+      "platforms": [
+        24,
+        37,
+        41
+      ],
       "player_perspectives": [
         3
       ],
@@ -34706,6 +35848,9 @@
       ],
       "name": "The Legend of Zelda: Twilight Princess",
       "parent_game": -1,
+      "platforms": [
+        21
+      ],
       "player_perspectives": [
         2
       ],
@@ -34829,6 +35974,10 @@
       ],
       "name": "The Legend of Zelda: Phantom Hourglass",
       "parent_game": -1,
+      "platforms": [
+        20,
+        41
+      ],
       "player_perspectives": [
         3
       ],
@@ -34920,6 +36069,10 @@
       ],
       "name": "The Legend of Zelda: Spirit Tracks",
       "parent_game": -1,
+      "platforms": [
+        20,
+        41
+      ],
       "player_perspectives": [
         3
       ],
@@ -34980,6 +36133,9 @@
       ],
       "name": "The Legend of Zelda: Ocarina of Time 3D",
       "parent_game": 1029,
+      "platforms": [
+        37
+      ],
       "player_perspectives": [
         2
       ],
@@ -35179,6 +36335,11 @@
       ],
       "name": "Alice: Madness Returns",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -35341,6 +36502,12 @@
       ],
       "name": "Hitman: Blood Money",
       "parent_game": -1,
+      "platforms": [
+        6,
+        8,
+        11,
+        12
+      ],
       "player_perspectives": [
         1,
         2
@@ -35403,6 +36570,12 @@
       ],
       "name": "Hitman: Contracts",
       "parent_game": -1,
+      "platforms": [
+        6,
+        8,
+        11,
+        14
+      ],
       "player_perspectives": [
         1,
         2
@@ -35481,6 +36654,13 @@
       ],
       "name": "Mirror's Edge",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        39,
+        74
+      ],
       "player_perspectives": [
         1
       ],
@@ -35554,6 +36734,12 @@
       ],
       "name": "Oil Rush",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        9,
+        14
+      ],
       "player_perspectives": [
         3
       ],
@@ -35612,6 +36798,11 @@
       ],
       "name": "Kingdoms of Amalur: Reckoning",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -35734,6 +36925,10 @@
       ],
       "name": "Alan Wake",
       "parent_game": -1,
+      "platforms": [
+        6,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -35852,6 +37047,14 @@
       ],
       "name": "Super Mario Bros. 3",
       "parent_game": -1,
+      "platforms": [
+        5,
+        18,
+        37,
+        41,
+        52,
+        99
+      ],
       "player_perspectives": [
         4
       ],
@@ -35970,6 +37173,14 @@
       ],
       "name": "Super Mario World",
       "parent_game": -1,
+      "platforms": [
+        5,
+        19,
+        41,
+        52,
+        58,
+        137
+      ],
       "player_perspectives": [
         4
       ],
@@ -36068,6 +37279,11 @@
       ],
       "name": "Super Mario World 2: Yoshi's Island",
       "parent_game": -1,
+      "platforms": [
+        19,
+        58,
+        306
+      ],
       "player_perspectives": [
         4
       ],
@@ -36161,6 +37377,11 @@
       ],
       "name": "Super Mario 64",
       "parent_game": -1,
+      "platforms": [
+        4,
+        5,
+        41
+      ],
       "player_perspectives": [
         2
       ],
@@ -36304,6 +37525,9 @@
       ],
       "name": "Super Mario Sunshine",
       "parent_game": -1,
+      "platforms": [
+        21
+      ],
       "player_perspectives": [
         2,
         3
@@ -36443,6 +37667,10 @@
       ],
       "name": "New Super Mario Bros.",
       "parent_game": -1,
+      "platforms": [
+        20,
+        41
+      ],
       "player_perspectives": [
         4
       ],
@@ -36521,6 +37749,9 @@
       ],
       "name": "Super Mario Galaxy",
       "parent_game": -1,
+      "platforms": [
+        5
+      ],
       "player_perspectives": [
         2
       ],
@@ -36657,6 +37888,10 @@
       ],
       "name": "Super Mario Galaxy 2",
       "parent_game": -1,
+      "platforms": [
+        5,
+        41
+      ],
       "player_perspectives": [
         2,
         3
@@ -36750,6 +37985,9 @@
       ],
       "name": "Super Mario 3D Land",
       "parent_game": -1,
+      "platforms": [
+        37
+      ],
       "player_perspectives": [
         2
       ],
@@ -36834,6 +38072,9 @@
       ],
       "name": "New Super Mario Bros. 2",
       "parent_game": -1,
+      "platforms": [
+        37
+      ],
       "player_perspectives": [
         4
       ],
@@ -37070,6 +38311,11 @@
       ],
       "name": "Resident Evil 6",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -37140,6 +38386,10 @@
       "name": "Donkey Kong",
       "name_glogAppendReleaseYear": true,
       "parent_game": 1086,
+      "platforms": [
+        33,
+        37
+      ],
       "player_perspectives": [
         4
       ],
@@ -37203,6 +38453,9 @@
       ],
       "name": "Donkey Kong Jungle Beat",
       "parent_game": -1,
+      "platforms": [
+        21
+      ],
       "player_perspectives": [
         4
       ],
@@ -37289,6 +38542,10 @@
       ],
       "name": "Donkey Kong Country Returns",
       "parent_game": -1,
+      "platforms": [
+        5,
+        41
+      ],
       "player_perspectives": [
         4
       ],
@@ -37393,6 +38650,14 @@
       ],
       "name": "Metroid",
       "parent_game": -1,
+      "platforms": [
+        5,
+        18,
+        37,
+        41,
+        51,
+        52
+      ],
       "player_perspectives": [
         4
       ],
@@ -37474,6 +38739,10 @@
       ],
       "name": "Metroid II: Return of Samus",
       "parent_game": -1,
+      "platforms": [
+        33,
+        37
+      ],
       "player_perspectives": [
         4
       ],
@@ -37576,6 +38845,13 @@
       ],
       "name": "Super Metroid",
       "parent_game": -1,
+      "platforms": [
+        5,
+        19,
+        41,
+        58,
+        137
+      ],
       "player_perspectives": [
         4
       ],
@@ -37721,6 +38997,11 @@
       ],
       "name": "Metroid Fusion",
       "parent_game": -1,
+      "platforms": [
+        24,
+        37,
+        41
+      ],
       "player_perspectives": [
         4
       ],
@@ -37882,6 +39163,9 @@
       ],
       "name": "Metroid Prime",
       "parent_game": -1,
+      "platforms": [
+        21
+      ],
       "player_perspectives": [
         1
       ],
@@ -37983,6 +39267,10 @@
       ],
       "name": "Metroid: Zero Mission",
       "parent_game": 1101,
+      "platforms": [
+        24,
+        41
+      ],
       "player_perspectives": [
         4
       ],
@@ -38116,6 +39404,9 @@
       ],
       "name": "Metroid Prime 2: Echoes",
       "parent_game": -1,
+      "platforms": [
+        21
+      ],
       "player_perspectives": [
         1
       ],
@@ -38170,6 +39461,9 @@
       "keywords": [],
       "name": "Metroid Prime Pinball",
       "parent_game": -1,
+      "platforms": [
+        20
+      ],
       "player_perspectives": [
         3
       ],
@@ -38266,6 +39560,10 @@
       ],
       "name": "Metroid Prime Hunters",
       "parent_game": -1,
+      "platforms": [
+        20,
+        41
+      ],
       "player_perspectives": [
         1
       ],
@@ -38406,6 +39704,9 @@
       ],
       "name": "Metroid Prime 3: Corruption",
       "parent_game": -1,
+      "platforms": [
+        5
+      ],
       "player_perspectives": [
         1
       ],
@@ -38555,6 +39856,10 @@
       ],
       "name": "Metroid Prime: Trilogy",
       "parent_game": -1,
+      "platforms": [
+        5,
+        41
+      ],
       "player_perspectives": [
         1
       ],
@@ -38666,6 +39971,10 @@
       ],
       "name": "Metroid: Other M",
       "parent_game": -1,
+      "platforms": [
+        5,
+        41
+      ],
       "player_perspectives": [
         1,
         2
@@ -38818,6 +40127,15 @@
       ],
       "name": "Watch Dogs",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        41,
+        48,
+        49,
+        170
+      ],
       "player_perspectives": [
         2
       ],
@@ -38980,6 +40298,13 @@
       ],
       "name": "Castlevania: Symphony of the Night",
       "parent_game": -1,
+      "platforms": [
+        7,
+        9,
+        12,
+        38,
+        46
+      ],
       "player_perspectives": [
         4
       ],
@@ -39077,6 +40402,10 @@
       ],
       "name": "Castlevania: Circle of the Moon",
       "parent_game": -1,
+      "platforms": [
+        24,
+        41
+      ],
       "player_perspectives": [
         4
       ],
@@ -39149,6 +40478,10 @@
       ],
       "name": "Castlevania: Harmony of Dissonance",
       "parent_game": -1,
+      "platforms": [
+        24,
+        41
+      ],
       "player_perspectives": [
         4
       ],
@@ -39249,6 +40582,10 @@
       ],
       "name": "Castlevania: Aria of Sorrow",
       "parent_game": -1,
+      "platforms": [
+        24,
+        41
+      ],
       "player_perspectives": [
         4
       ],
@@ -39393,6 +40730,9 @@
       ],
       "name": "Castlevania: Dawn of Sorrow",
       "parent_game": -1,
+      "platforms": [
+        20
+      ],
       "player_perspectives": [
         4
       ],
@@ -39505,6 +40845,9 @@
       ],
       "name": "Castlevania: Portrait of Ruin",
       "parent_game": -1,
+      "platforms": [
+        20
+      ],
       "player_perspectives": [
         4
       ],
@@ -39649,6 +40992,9 @@
       ],
       "name": "Castlevania: Order of Ecclesia",
       "parent_game": -1,
+      "platforms": [
+        20
+      ],
       "player_perspectives": [
         4
       ],
@@ -39734,6 +41080,9 @@
       ],
       "name": "Castlevania: Lords of Shadow - Mirror of Fate",
       "parent_game": -1,
+      "platforms": [
+        37
+      ],
       "player_perspectives": [
         4
       ],
@@ -39881,6 +41230,13 @@
       ],
       "name": "Tomb Raider II",
       "parent_game": -1,
+      "platforms": [
+        6,
+        7,
+        9,
+        14,
+        38
+      ],
       "player_perspectives": [
         2
       ],
@@ -39998,6 +41354,12 @@
       ],
       "name": "Tomb Raider: Legend",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        113
+      ],
       "player_perspectives": [
         2
       ],
@@ -40217,6 +41579,13 @@
       "name": "Tomb Raider",
       "name_glogAppendReleaseYear": true,
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        9,
+        12,
+        14
+      ],
       "player_perspectives": [
         2
       ],
@@ -40273,6 +41642,9 @@
       "keywords": [],
       "name": "Meteos",
       "parent_game": -1,
+      "platforms": [
+        20
+      ],
       "player_perspectives": [
         4
       ],
@@ -40369,6 +41741,10 @@
       ],
       "name": "Golden Sun",
       "parent_game": -1,
+      "platforms": [
+        24,
+        41
+      ],
       "player_perspectives": [
         2,
         3
@@ -40426,6 +41802,10 @@
       ],
       "name": "Lufia II: Rise of the Sinistrals",
       "parent_game": -1,
+      "platforms": [
+        19,
+        58
+      ],
       "player_perspectives": [
         4
       ],
@@ -40535,6 +41915,11 @@
       ],
       "name": "Castlevania: Lords of Shadow 2",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -40637,6 +42022,12 @@
       ],
       "name": "Crash Bandicoot",
       "parent_game": -1,
+      "platforms": [
+        7,
+        9,
+        38,
+        46
+      ],
       "player_perspectives": [
         2
       ],
@@ -40699,6 +42090,9 @@
       ],
       "name": "Tales of Phantasia",
       "parent_game": -1,
+      "platforms": [
+        58
+      ],
       "player_perspectives": [
         3,
         4
@@ -40774,6 +42168,9 @@
       ],
       "name": "Tales of Symphonia",
       "parent_game": -1,
+      "platforms": [
+        21
+      ],
       "player_perspectives": [
         2
       ],
@@ -40902,6 +42299,9 @@
       ],
       "name": "Tales of Vesperia",
       "parent_game": -1,
+      "platforms": [
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -40959,6 +42359,9 @@
       "name": "Tales of Hearts: Anime Movie Edition",
       "name_glogOverride": "Tales of Hearts",
       "parent_game": -1,
+      "platforms": [
+        20
+      ],
       "player_perspectives": [
         3,
         4
@@ -41097,6 +42500,9 @@
       ],
       "name": "Kingdom Hearts",
       "parent_game": -1,
+      "platforms": [
+        8
+      ],
       "player_perspectives": [
         2
       ],
@@ -41158,6 +42564,11 @@
       ],
       "name": "Kingdom Hearts II",
       "parent_game": -1,
+      "platforms": [
+        8,
+        9,
+        48
+      ],
       "player_perspectives": [
         2
       ],
@@ -41265,6 +42676,9 @@
       ],
       "name": "Kingdom Hearts 358/2 Days",
       "parent_game": -1,
+      "platforms": [
+        20
+      ],
       "player_perspectives": [
         2
       ],
@@ -41349,6 +42763,10 @@
       ],
       "name": "Phantasy Star",
       "parent_game": -1,
+      "platforms": [
+        5,
+        64
+      ],
       "player_perspectives": [
         1,
         3
@@ -41417,6 +42835,9 @@
       ],
       "name": "The Lost Vikings 2",
       "parent_game": -1,
+      "platforms": [
+        19
+      ],
       "player_perspectives": [
         4
       ],
@@ -41560,6 +42981,14 @@
       ],
       "name": "South Park: The Stick of Truth",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         2,
         4
@@ -41670,6 +43099,12 @@
       ],
       "name": "Assassin's Creed III",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        41
+      ],
       "player_perspectives": [
         2
       ],
@@ -41788,6 +43223,13 @@
       ],
       "name": "Sleeping Dogs",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        48,
+        49
+      ],
       "player_perspectives": [
         2
       ],
@@ -41880,6 +43322,12 @@
       ],
       "name": "Darksiders II",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        41
+      ],
       "player_perspectives": [
         2
       ],
@@ -41964,6 +43412,12 @@
       ],
       "name": "Darksiders",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -42056,6 +43510,11 @@
       ],
       "name": "Ōkami",
       "parent_game": -1,
+      "platforms": [
+        5,
+        8,
+        9
+      ],
       "player_perspectives": [
         2
       ],
@@ -42137,6 +43596,22 @@
       ],
       "name": "SimCity",
       "parent_game": -1,
+      "platforms": [
+        6,
+        13,
+        14,
+        15,
+        16,
+        25,
+        26,
+        63,
+        69,
+        116,
+        118,
+        121,
+        134,
+        149
+      ],
       "player_perspectives": [
         3
       ],
@@ -42226,6 +43701,10 @@
       "name": "SimCity",
       "name_glogAppendReleaseYear": true,
       "parent_game": -1,
+      "platforms": [
+        6,
+        14
+      ],
       "player_perspectives": [
         3
       ],
@@ -42283,6 +43762,10 @@
       ],
       "name": "Deadly Premonition",
       "parent_game": -1,
+      "platforms": [
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -42410,6 +43893,17 @@
       ],
       "name": "Plants vs. Zombies",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        14,
+        34,
+        39,
+        46,
+        74,
+        159
+      ],
       "player_perspectives": [
         4
       ],
@@ -42502,6 +43996,9 @@
       ],
       "name": "Resistance: Fall of Man",
       "parent_game": -1,
+      "platforms": [
+        9
+      ],
       "player_perspectives": [
         1
       ],
@@ -42621,6 +44118,12 @@
       ],
       "name": "Hearthstone",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14,
+        34,
+        39
+      ],
       "player_perspectives": [
         3,
         5
@@ -42703,6 +44206,10 @@
       ],
       "name": "Lollipop Chainsaw",
       "parent_game": -1,
+      "platforms": [
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -42781,6 +44288,9 @@
       ],
       "name": "Guitar Hero",
       "parent_game": -1,
+      "platforms": [
+        8
+      ],
       "player_perspectives": [
         6
       ],
@@ -42887,6 +44397,9 @@
       ],
       "name": "Ratchet & Clank",
       "parent_game": -1,
+      "platforms": [
+        8
+      ],
       "player_perspectives": [
         2
       ],
@@ -43030,6 +44543,12 @@
       ],
       "name": "Tom Clancy's Splinter Cell: Blacklist",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        41
+      ],
       "player_perspectives": [
         2
       ],
@@ -43199,6 +44718,13 @@
       ],
       "name": "XCOM: Enemy Unknown",
       "parent_game": 24,
+      "platforms": [
+        3,
+        6,
+        9,
+        12,
+        14
+      ],
       "player_perspectives": [
         3
       ],
@@ -43328,6 +44854,19 @@
       ],
       "name": "Limbo",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        9,
+        12,
+        14,
+        34,
+        39,
+        46,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -43429,6 +44968,10 @@
       ],
       "name": "Pong",
       "parent_game": -1,
+      "platforms": [
+        52,
+        377
+      ],
       "player_perspectives": [
         3
       ],
@@ -43553,6 +45096,17 @@
       ],
       "name": "Brothers: A Tale of Two Sons",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        34,
+        39,
+        48,
+        49,
+        74,
+        130
+      ],
       "player_perspectives": [
         2
       ],
@@ -43624,6 +45178,14 @@
       ],
       "name": "Torchlight II",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         3
       ],
@@ -43769,6 +45331,17 @@
       ],
       "name": "Psychonauts",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        8,
+        9,
+        11,
+        12,
+        14,
+        48,
+        49
+      ],
       "player_perspectives": [
         2
       ],
@@ -43866,6 +45439,11 @@
       ],
       "name": "Dustforce DX",
       "parent_game": 94073,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -43978,6 +45556,13 @@
       ],
       "name": "Beyond Good & Evil",
       "parent_game": -1,
+      "platforms": [
+        6,
+        8,
+        11,
+        12,
+        21
+      ],
       "player_perspectives": [
         1,
         2
@@ -44046,6 +45631,9 @@
       ],
       "name": "The World Ends with You",
       "parent_game": -1,
+      "platforms": [
+        20
+      ],
       "player_perspectives": [
         4
       ],
@@ -44105,6 +45693,10 @@
       ],
       "name": "Xenogears",
       "parent_game": -1,
+      "platforms": [
+        7,
+        9
+      ],
       "player_perspectives": [
         2,
         3
@@ -44157,6 +45749,10 @@
       ],
       "name": "Ghost Trick: Phantom Detective",
       "parent_game": -1,
+      "platforms": [
+        20,
+        39
+      ],
       "player_perspectives": [
         4
       ],
@@ -44250,6 +45846,12 @@
       ],
       "name": "Journey",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        39,
+        48
+      ],
       "player_perspectives": [
         2,
         4
@@ -44330,6 +45932,13 @@
       ],
       "name": "flOw",
       "parent_game": -1,
+      "platforms": [
+        9,
+        38,
+        46,
+        48,
+        82
+      ],
       "player_perspectives": [
         3
       ],
@@ -44401,6 +46010,13 @@
       ],
       "name": "Flower",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        39,
+        46,
+        48
+      ],
       "player_perspectives": [
         2
       ],
@@ -44457,6 +46073,9 @@
       ],
       "name": "Secret of Evermore",
       "parent_game": -1,
+      "platforms": [
+        19
+      ],
       "player_perspectives": [
         2
       ],
@@ -44536,6 +46155,15 @@
       ],
       "name": "Little Inferno",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        34,
+        39,
+        41,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -44630,6 +46258,12 @@
       ],
       "name": "Sniper: Ghost Warrior",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         1
       ],
@@ -44795,6 +46429,13 @@
       ],
       "name": "Spec Ops: The Line",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        9,
+        12,
+        14
+      ],
       "player_perspectives": [
         2
       ],
@@ -44887,6 +46528,20 @@
       ],
       "name": "Hotline Miami",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        9,
+        14,
+        34,
+        46,
+        48,
+        49,
+        130,
+        167,
+        169,
+        170
+      ],
       "player_perspectives": [
         3
       ],
@@ -44951,6 +46606,11 @@
       ],
       "name": "Star Wars: 1313",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -45031,6 +46691,10 @@
       ],
       "name": "Professor Layton and the Curious Village",
       "parent_game": -1,
+      "platforms": [
+        20,
+        55
+      ],
       "player_perspectives": [
         4,
         5
@@ -45118,6 +46782,10 @@
       ],
       "name": "Professor Layton and the Diabolical Box",
       "parent_game": -1,
+      "platforms": [
+        20,
+        55
+      ],
       "player_perspectives": [
         4,
         5
@@ -45182,6 +46850,9 @@
       ],
       "name": "Professor Layton vs. Phoenix Wright: Ace Attorney",
       "parent_game": -1,
+      "platforms": [
+        37
+      ],
       "player_perspectives": [
         2
       ],
@@ -45249,6 +46920,19 @@
       ],
       "name": "Metal Slug",
       "parent_game": -1,
+      "platforms": [
+        3,
+        5,
+        6,
+        7,
+        14,
+        32,
+        34,
+        39,
+        79,
+        80,
+        136
+      ],
       "player_perspectives": [
         4
       ],
@@ -45372,6 +47056,9 @@
       ],
       "name": "Phoenix Wright: Ace Attorney",
       "parent_game": 221280,
+      "platforms": [
+        20
+      ],
       "player_perspectives": [
         1,
         4,
@@ -45481,6 +47168,11 @@
       ],
       "name": "Phoenix Wright: Ace Attorney - Justice for All",
       "parent_game": 221289,
+      "platforms": [
+        5,
+        6,
+        20
+      ],
       "player_perspectives": [
         1,
         5
@@ -45583,6 +47275,11 @@
       ],
       "name": "Phoenix Wright: Ace Attorney - Trials and Tribulations",
       "parent_game": 221290,
+      "platforms": [
+        5,
+        6,
+        20
+      ],
       "player_perspectives": [
         1,
         2,
@@ -45673,6 +47370,12 @@
       ],
       "name": "Apollo Justice: Ace Attorney",
       "parent_game": -1,
+      "platforms": [
+        20,
+        34,
+        37,
+        39
+      ],
       "player_perspectives": [
         1,
         4,
@@ -45750,6 +47453,15 @@
       ],
       "name": "Ace Attorney Investigations: Miles Edgeworth",
       "parent_game": -1,
+      "platforms": [
+        6,
+        20,
+        34,
+        39,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         2,
         4
@@ -45831,6 +47543,11 @@
       ],
       "name": "Phoenix Wright: Ace Attorney - Dual Destinies",
       "parent_game": -1,
+      "platforms": [
+        34,
+        37,
+        39
+      ],
       "player_perspectives": [
         4
       ],
@@ -45951,6 +47668,9 @@
       ],
       "name": "Fire Emblem: Path of Radiance",
       "parent_game": -1,
+      "platforms": [
+        21
+      ],
       "player_perspectives": [
         2,
         3,
@@ -46068,6 +47788,9 @@
       ],
       "name": "Fire Emblem: Radiant Dawn",
       "parent_game": -1,
+      "platforms": [
+        5
+      ],
       "player_perspectives": [
         3
       ],
@@ -46221,6 +47944,9 @@
       ],
       "name": "Perfect Dark",
       "parent_game": -1,
+      "platforms": [
+        4
+      ],
       "player_perspectives": [
         1
       ],
@@ -46341,6 +48067,9 @@
       ],
       "name": "Perfect Dark Zero",
       "parent_game": -1,
+      "platforms": [
+        12
+      ],
       "player_perspectives": [
         1
       ],
@@ -46400,6 +48129,11 @@
       ],
       "name": "Sin and Punishment",
       "parent_game": -1,
+      "platforms": [
+        4,
+        5,
+        41
+      ],
       "player_perspectives": [
         2
       ],
@@ -46475,6 +48209,10 @@
       ],
       "name": "Sin & Punishment: Star Successor",
       "parent_game": -1,
+      "platforms": [
+        5,
+        41
+      ],
       "player_perspectives": [
         2
       ],
@@ -46550,6 +48288,9 @@
       ],
       "name": "Zone of the Enders",
       "parent_game": -1,
+      "platforms": [
+        8
+      ],
       "player_perspectives": [
         2
       ],
@@ -46617,6 +48358,9 @@
       ],
       "name": "SimCopter",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [
         1,
         2
@@ -46676,6 +48420,9 @@
       ],
       "name": "Pokémon Pearl Version",
       "parent_game": -1,
+      "platforms": [
+        20
+      ],
       "player_perspectives": [
         3,
         4
@@ -46790,6 +48537,10 @@
       ],
       "name": "Jak and Daxter: The Precursor Legacy",
       "parent_game": -1,
+      "platforms": [
+        8,
+        48
+      ],
       "player_perspectives": [
         2
       ],
@@ -46857,6 +48608,10 @@
       ],
       "name": "Pokémon Red Version",
       "parent_game": -1,
+      "platforms": [
+        33,
+        37
+      ],
       "player_perspectives": [
         3,
         4
@@ -46970,6 +48725,13 @@
       ],
       "name": "Pillars of Eternity",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        48,
+        130
+      ],
       "player_perspectives": [
         3
       ],
@@ -47040,6 +48802,9 @@
       ],
       "name": "Star Citizen",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [
         1,
         2,
@@ -47124,6 +48889,10 @@
       ],
       "name": "Super Smash Bros.",
       "parent_game": -1,
+      "platforms": [
+        4,
+        5
+      ],
       "player_perspectives": [
         4
       ],
@@ -47214,6 +48983,9 @@
       ],
       "name": "Super Smash Bros. Melee",
       "parent_game": -1,
+      "platforms": [
+        21
+      ],
       "player_perspectives": [
         4
       ],
@@ -47459,6 +49231,9 @@
       ],
       "name": "Super Smash Bros. Brawl",
       "parent_game": -1,
+      "platforms": [
+        5
+      ],
       "player_perspectives": [
         4
       ],
@@ -47514,6 +49289,11 @@
       ],
       "name": "James Bond 007: Nightfire",
       "parent_game": -1,
+      "platforms": [
+        8,
+        11,
+        21
+      ],
       "player_perspectives": [
         1
       ],
@@ -47602,6 +49382,9 @@
       ],
       "name": "GoldenEye 007",
       "parent_game": -1,
+      "platforms": [
+        4
+      ],
       "player_perspectives": [
         1
       ],
@@ -47739,6 +49522,16 @@
       ],
       "name": "Streets of Rage",
       "parent_game": -1,
+      "platforms": [
+        3,
+        5,
+        6,
+        14,
+        29,
+        34,
+        39,
+        52
+      ],
       "player_perspectives": [
         4
       ],
@@ -47846,6 +49639,10 @@
       ],
       "name": "Advance Wars",
       "parent_game": -1,
+      "platforms": [
+        24,
+        41
+      ],
       "player_perspectives": [
         3
       ],
@@ -47911,6 +49708,10 @@
       ],
       "name": "Wario: Master of Disguise",
       "parent_game": -1,
+      "platforms": [
+        20,
+        41
+      ],
       "player_perspectives": [
         4
       ],
@@ -48006,6 +49807,10 @@
       ],
       "name": "WarioWare: Smooth Moves",
       "parent_game": -1,
+      "platforms": [
+        5,
+        41
+      ],
       "player_perspectives": [
         1,
         2,
@@ -48117,6 +49922,15 @@
       ],
       "name": "Mega Man",
       "parent_game": -1,
+      "platforms": [
+        5,
+        9,
+        18,
+        37,
+        41,
+        46,
+        99
+      ],
       "player_perspectives": [
         4
       ],
@@ -48231,6 +50045,13 @@
       ],
       "name": "Mega Man 7",
       "parent_game": -1,
+      "platforms": [
+        19,
+        37,
+        41,
+        58,
+        137
+      ],
       "player_perspectives": [
         4
       ],
@@ -48317,6 +50138,13 @@
       ],
       "name": "Mega Man 8",
       "parent_game": -1,
+      "platforms": [
+        7,
+        9,
+        32,
+        38,
+        46
+      ],
       "player_perspectives": [
         4
       ],
@@ -48389,6 +50217,11 @@
       ],
       "name": "Mega Man & Bass",
       "parent_game": -1,
+      "platforms": [
+        24,
+        41,
+        58
+      ],
       "player_perspectives": [
         4
       ],
@@ -48450,6 +50283,10 @@
       ],
       "name": "Mega Man Soccer",
       "parent_game": -1,
+      "platforms": [
+        19,
+        58
+      ],
       "player_perspectives": [
         3
       ],
@@ -48524,6 +50361,16 @@
       ],
       "name": "Mega Man X",
       "parent_game": -1,
+      "platforms": [
+        5,
+        13,
+        19,
+        37,
+        39,
+        41,
+        58,
+        137
+      ],
       "player_perspectives": [
         4
       ],
@@ -48600,6 +50447,10 @@
       ],
       "name": "Mega Man X: Command Mission",
       "parent_game": -1,
+      "platforms": [
+        8,
+        21
+      ],
       "player_perspectives": [
         4
       ],
@@ -48677,6 +50528,10 @@
       ],
       "name": "Mega Man Battle Network",
       "parent_game": -1,
+      "platforms": [
+        24,
+        41
+      ],
       "player_perspectives": [
         3,
         4
@@ -48741,6 +50596,9 @@
       ],
       "name": "Mega Man Network Transmission",
       "parent_game": -1,
+      "platforms": [
+        21
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -48822,6 +50680,10 @@
       ],
       "name": "Mega Man Zero",
       "parent_game": -1,
+      "platforms": [
+        24,
+        41
+      ],
       "player_perspectives": [
         4
       ],
@@ -48905,6 +50767,10 @@
       ],
       "name": "Mega Man Zero 2",
       "parent_game": -1,
+      "platforms": [
+        24,
+        41
+      ],
       "player_perspectives": [
         4
       ],
@@ -48969,6 +50835,10 @@
       ],
       "name": "Mega Man Zero 3",
       "parent_game": -1,
+      "platforms": [
+        24,
+        41
+      ],
       "player_perspectives": [
         4
       ],
@@ -49044,6 +50914,9 @@
       ],
       "name": "Mega Man ZX",
       "parent_game": -1,
+      "platforms": [
+        20
+      ],
       "player_perspectives": [
         4
       ],
@@ -49125,6 +50998,9 @@
       ],
       "name": "Mega Man ZX Advent",
       "parent_game": -1,
+      "platforms": [
+        20
+      ],
       "player_perspectives": [
         4
       ],
@@ -49253,6 +51129,9 @@
       ],
       "name": "Ratchet & Clank Future: Tools of Destruction",
       "parent_game": -1,
+      "platforms": [
+        9
+      ],
       "player_perspectives": [
         2
       ],
@@ -49361,6 +51240,9 @@
       ],
       "name": "Sly Cooper and the Thievius Raccoonus",
       "parent_game": -1,
+      "platforms": [
+        8
+      ],
       "player_perspectives": [
         2
       ],
@@ -49453,6 +51335,9 @@
       ],
       "name": "Sly 2: Band of Thieves",
       "parent_game": -1,
+      "platforms": [
+        8
+      ],
       "player_perspectives": [
         2
       ],
@@ -49553,6 +51438,9 @@
       ],
       "name": "Sly 3: Honor Among Thieves",
       "parent_game": -1,
+      "platforms": [
+        8
+      ],
       "player_perspectives": [
         2
       ],
@@ -49636,6 +51524,12 @@
       ],
       "name": "Chrono Trigger",
       "parent_game": -1,
+      "platforms": [
+        5,
+        19,
+        58,
+        306
+      ],
       "player_perspectives": [
         3
       ],
@@ -49799,6 +51693,10 @@
       ],
       "name": "Chrono Cross",
       "parent_game": -1,
+      "platforms": [
+        7,
+        9
+      ],
       "player_perspectives": [
         2
       ],
@@ -49915,6 +51813,11 @@
       ],
       "name": "Remember Me",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -50008,6 +51911,19 @@
       ],
       "name": "The Walking Dead",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        9,
+        12,
+        14,
+        34,
+        39,
+        46,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         2,
         3
@@ -50154,6 +52070,10 @@
       ],
       "name": "Spore",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14
+      ],
       "player_perspectives": [
         2,
         3
@@ -50221,6 +52141,14 @@
       ],
       "name": "Cyberpunk 2077",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49,
+        167,
+        169,
+        170
+      ],
       "player_perspectives": [
         1,
         2
@@ -50373,6 +52301,23 @@
       ],
       "name": "Terraria",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        9,
+        12,
+        14,
+        34,
+        37,
+        39,
+        41,
+        46,
+        48,
+        49,
+        74,
+        130,
+        170
+      ],
       "player_perspectives": [
         4
       ],
@@ -50460,6 +52405,16 @@
       "keywords": [],
       "name": "Baldur's Gate: Enhanced Edition",
       "parent_game": 5,
+      "platforms": [
+        3,
+        6,
+        14,
+        34,
+        39,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         3
       ],
@@ -50567,6 +52522,14 @@
       ],
       "name": "Might & Magic: Clash of Heroes",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        20,
+        34,
+        39
+      ],
       "player_perspectives": [
         3
       ],
@@ -50656,6 +52619,12 @@
       ],
       "name": "Pid",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        14
+      ],
       "player_perspectives": [
         4
       ],
@@ -50755,6 +52724,15 @@
       ],
       "name": "Gone Home",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        39,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         1
       ],
@@ -50835,6 +52813,10 @@
       ],
       "name": "Grim Dawn",
       "parent_game": -1,
+      "platforms": [
+        6,
+        49
+      ],
       "player_perspectives": [
         3
       ],
@@ -50923,6 +52905,13 @@
       ],
       "name": "Path of Exile",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14,
+        48,
+        49,
+        167
+      ],
       "player_perspectives": [
         3
       ],
@@ -51011,6 +53000,12 @@
       ],
       "name": "Indigo Prophecy",
       "parent_game": -1,
+      "platforms": [
+        6,
+        8,
+        11,
+        48
+      ],
       "player_perspectives": [
         2
       ],
@@ -51077,6 +53072,11 @@
       ],
       "name": "Beyond Good & Evil 2",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49
+      ],
       "player_perspectives": [
         2
       ],
@@ -51209,6 +53209,12 @@
       ],
       "name": "Destiny",
       "parent_game": -1,
+      "platforms": [
+        9,
+        12,
+        48,
+        49
+      ],
       "player_perspectives": [
         1,
         2
@@ -51286,6 +53292,10 @@
       ],
       "name": "Driveclub",
       "parent_game": -1,
+      "platforms": [
+        48,
+        165
+      ],
       "player_perspectives": [
         1,
         2,
@@ -51401,6 +53411,14 @@
       ],
       "name": "The Witcher 3: Wild Hunt",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49,
+        130,
+        167,
+        169
+      ],
       "player_perspectives": [
         2
       ],
@@ -51471,6 +53489,10 @@
       "name": "Alone in the Dark",
       "name_glogAppendReleaseYear": true,
       "parent_game": -1,
+      "platforms": [
+        6,
+        12
+      ],
       "player_perspectives": [
         1,
         2
@@ -51541,6 +53563,11 @@
       ],
       "name": "Red Dead Revolver",
       "parent_game": -1,
+      "platforms": [
+        8,
+        11,
+        48
+      ],
       "player_perspectives": [
         2
       ],
@@ -51739,6 +53766,16 @@
       ],
       "name": "Assassin's Creed IV Black Flag",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        41,
+        48,
+        49,
+        130,
+        170
+      ],
       "player_perspectives": [
         2
       ],
@@ -51885,6 +53922,12 @@
       ],
       "name": "Call of Juarez: Gunslinger",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        130
+      ],
       "player_perspectives": [
         1
       ],
@@ -52049,6 +54092,13 @@
       ],
       "name": "Battlefield 4",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        48,
+        49
+      ],
       "player_perspectives": [
         1,
         2
@@ -52289,6 +54339,13 @@
       ],
       "name": "Saints Row IV",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        48,
+        49
+      ],
       "player_perspectives": [
         2
       ],
@@ -52416,6 +54473,17 @@
       ],
       "name": "Bastion",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        12,
+        14,
+        39,
+        46,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         3
       ],
@@ -52629,6 +54697,13 @@
       ],
       "name": "Metal Gear Solid V: The Phantom Pain",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        48,
+        49
+      ],
       "player_perspectives": [
         2
       ],
@@ -52792,6 +54867,13 @@
       ],
       "name": "XIII",
       "parent_game": -1,
+      "platforms": [
+        6,
+        8,
+        11,
+        14,
+        21
+      ],
       "player_perspectives": [
         1
       ],
@@ -52899,6 +54981,18 @@
       ],
       "name": "VVVVVV",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        34,
+        37,
+        39,
+        46,
+        48,
+        72,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -53043,6 +55137,17 @@
       ],
       "name": "Fez",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        9,
+        12,
+        14,
+        39,
+        46,
+        48,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -53160,6 +55265,12 @@
       ],
       "name": "Far Cry 3: Blood Dragon",
       "parent_game": 529,
+      "platforms": [
+        6,
+        9,
+        12,
+        170
+      ],
       "player_perspectives": [
         1
       ],
@@ -53341,6 +55452,12 @@
       ],
       "name": "Batman: Arkham Origins",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        41
+      ],
       "player_perspectives": [
         2
       ],
@@ -53441,6 +55558,13 @@
       ],
       "name": "Torment: Tides of Numenera",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        48,
+        49
+      ],
       "player_perspectives": [
         3
       ],
@@ -53511,6 +55635,13 @@
       ],
       "name": "Evoland",
       "parent_game": 315652,
+      "platforms": [
+        3,
+        6,
+        14,
+        34,
+        39
+      ],
       "player_perspectives": [
         3,
         4
@@ -53695,6 +55826,13 @@
       ],
       "name": "Wolfenstein: The New Order",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        48,
+        49
+      ],
       "player_perspectives": [
         1
       ],
@@ -53882,6 +56020,14 @@
       ],
       "name": "Call of Duty: Ghosts",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        41,
+        48,
+        49
+      ],
       "player_perspectives": [
         1
       ],
@@ -54013,6 +56159,10 @@
       ],
       "name": "Magicka",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -54191,6 +56341,16 @@
       ],
       "name": "LEGO Marvel Super Heroes",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        14,
+        41,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         2,
         4
@@ -54281,6 +56441,10 @@
       ],
       "name": "OutRun",
       "parent_game": -1,
+      "platforms": [
+        52,
+        121
+      ],
       "player_perspectives": [
         2
       ],
@@ -54388,6 +56552,11 @@
       ],
       "name": "Antichamber",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         1
       ],
@@ -54449,6 +56618,9 @@
       ],
       "name": "Warlock: Master of the Arcane",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [
         3
       ],
@@ -54542,6 +56714,11 @@
       ],
       "name": "Titanfall",
       "parent_game": -1,
+      "platforms": [
+        6,
+        12,
+        49
+      ],
       "player_perspectives": [
         1
       ],
@@ -54639,6 +56816,12 @@
       ],
       "name": "Mark of the Ninja",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        12,
+        14
+      ],
       "player_perspectives": [
         4
       ],
@@ -54754,6 +56937,15 @@
       ],
       "name": "Dust: An Elysian Tail",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        12,
+        14,
+        39,
+        48,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -54837,6 +57029,11 @@
       ],
       "name": "Bayonetta",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -54967,6 +57164,9 @@
       ],
       "name": "Banjo-Kazooie",
       "parent_game": -1,
+      "platforms": [
+        4
+      ],
       "player_perspectives": [
         2
       ],
@@ -55110,6 +57310,11 @@
       ],
       "name": "Dark Souls",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -55184,6 +57389,13 @@
       ],
       "name": "Proteus",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        9,
+        14,
+        46
+      ],
       "player_perspectives": [
         1
       ],
@@ -55291,6 +57503,9 @@
       ],
       "name": "New Super Mario Bros. U",
       "parent_game": -1,
+      "platforms": [
+        41
+      ],
       "player_perspectives": [
         4
       ],
@@ -55399,6 +57614,9 @@
       ],
       "name": "Nintendo Land",
       "parent_game": -1,
+      "platforms": [
+        41
+      ],
       "player_perspectives": [
         1,
         2,
@@ -55520,6 +57738,14 @@
       ],
       "name": "Sonic & All-Stars Racing Transformed",
       "parent_game": -1,
+      "platforms": [
+        9,
+        12,
+        34,
+        39,
+        41,
+        46
+      ],
       "player_perspectives": [
         2
       ],
@@ -55646,6 +57872,18 @@
       ],
       "name": "The Cave",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        9,
+        12,
+        14,
+        34,
+        39,
+        41,
+        49,
+        72
+      ],
       "player_perspectives": [
         4
       ],
@@ -55714,6 +57952,12 @@
       ],
       "name": "Mighty Switch Force! Hyper Drive Edition",
       "parent_game": 22919,
+      "platforms": [
+        6,
+        41,
+        48,
+        49
+      ],
       "player_perspectives": [
         4
       ],
@@ -55801,6 +58045,13 @@
       ],
       "name": "LEGO City Undercover",
       "parent_game": -1,
+      "platforms": [
+        6,
+        41,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         2
       ],
@@ -55878,6 +58129,10 @@
       ],
       "name": "New Super Mario Bros. Wii",
       "parent_game": -1,
+      "platforms": [
+        5,
+        41
+      ],
       "player_perspectives": [
         4
       ],
@@ -55955,6 +58210,9 @@
       ],
       "name": "Red Steel 2",
       "parent_game": -1,
+      "platforms": [
+        5
+      ],
       "player_perspectives": [
         1
       ],
@@ -56073,6 +58331,9 @@
       ],
       "name": "Super Mario 3D World",
       "parent_game": -1,
+      "platforms": [
+        41
+      ],
       "player_perspectives": [
         2
       ],
@@ -56167,6 +58428,9 @@
       ],
       "name": "Wii Sports",
       "parent_game": -1,
+      "platforms": [
+        5
+      ],
       "player_perspectives": [
         1,
         2
@@ -56262,6 +58526,9 @@
       ],
       "name": "Wii Sports Resort",
       "parent_game": -1,
+      "platforms": [
+        5
+      ],
       "player_perspectives": [
         1,
         2
@@ -56326,6 +58593,9 @@
       ],
       "name": "Mario Kart Wii",
       "parent_game": -1,
+      "platforms": [
+        5
+      ],
       "player_perspectives": [
         2
       ],
@@ -56390,6 +58660,10 @@
       ],
       "name": "Kirby's Epic Yarn",
       "parent_game": -1,
+      "platforms": [
+        5,
+        41
+      ],
       "player_perspectives": [
         4
       ],
@@ -56466,6 +58740,9 @@
       ],
       "name": "Wii Play",
       "parent_game": -1,
+      "platforms": [
+        5
+      ],
       "player_perspectives": [
         1,
         2,
@@ -56543,6 +58820,9 @@
       ],
       "name": "Wii Fit",
       "parent_game": -1,
+      "platforms": [
+        5
+      ],
       "player_perspectives": [
         1,
         2
@@ -56670,6 +58950,10 @@
       ],
       "name": "Super Paper Mario",
       "parent_game": -1,
+      "platforms": [
+        5,
+        41
+      ],
       "player_perspectives": [
         2,
         4
@@ -56754,6 +59038,10 @@
       "name": "Punch-Out!!",
       "name_glogAppendReleaseYear": true,
       "parent_game": 84799,
+      "platforms": [
+        5,
+        41
+      ],
       "player_perspectives": [
         2
       ],
@@ -56835,6 +59123,9 @@
       ],
       "name": "Shadow of the Colossus",
       "parent_game": -1,
+      "platforms": [
+        8
+      ],
       "player_perspectives": [
         2
       ],
@@ -56922,6 +59213,9 @@
       ],
       "name": "Pikmin",
       "parent_game": -1,
+      "platforms": [
+        21
+      ],
       "player_perspectives": [
         3
       ],
@@ -57003,6 +59297,9 @@
       ],
       "name": "Pikmin 2",
       "parent_game": -1,
+      "platforms": [
+        21
+      ],
       "player_perspectives": [
         3
       ],
@@ -57089,6 +59386,9 @@
       ],
       "name": "Pikmin 3",
       "parent_game": -1,
+      "platforms": [
+        41
+      ],
       "player_perspectives": [
         3
       ],
@@ -57196,6 +59496,13 @@
       ],
       "name": "Frozen Synapse",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        34,
+        39
+      ],
       "player_perspectives": [
         3
       ],
@@ -57289,6 +59596,13 @@
       ],
       "name": "DeathSpank",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        9,
+        12,
+        14
+      ],
       "player_perspectives": [
         2
       ],
@@ -57372,6 +59686,10 @@
       ],
       "name": "Mario Strikers Charged",
       "parent_game": -1,
+      "platforms": [
+        5,
+        41
+      ],
       "player_perspectives": [
         3
       ],
@@ -57451,6 +59769,9 @@
       ],
       "name": "Red Steel",
       "parent_game": -1,
+      "platforms": [
+        5
+      ],
       "player_perspectives": [
         1
       ],
@@ -57522,6 +59843,9 @@
       ],
       "name": "Boom Blox",
       "parent_game": -1,
+      "platforms": [
+        5
+      ],
       "player_perspectives": [
         1,
         3
@@ -57569,6 +59893,10 @@
       "keywords": [],
       "name": "Zack & Wiki: Quest for Barbaros' Treasure",
       "parent_game": -1,
+      "platforms": [
+        5,
+        41
+      ],
       "player_perspectives": [
         4
       ],
@@ -57671,6 +59999,10 @@
       ],
       "name": "Muramasa: The Demon Blade",
       "parent_game": -1,
+      "platforms": [
+        5,
+        46
+      ],
       "player_perspectives": [
         4
       ],
@@ -57805,6 +60137,11 @@
       ],
       "name": "No More Heroes",
       "parent_game": -1,
+      "platforms": [
+        5,
+        6,
+        130
+      ],
       "player_perspectives": [
         2
       ],
@@ -57883,6 +60220,11 @@
       ],
       "name": "No More Heroes 2: Desperate Struggle",
       "parent_game": -1,
+      "platforms": [
+        5,
+        6,
+        130
+      ],
       "player_perspectives": [
         2
       ],
@@ -57975,6 +60317,9 @@
       ],
       "name": "The Legend of Zelda: The Wind Waker HD",
       "parent_game": 1033,
+      "platforms": [
+        41
+      ],
       "player_perspectives": [
         2
       ],
@@ -58077,6 +60422,19 @@
       ],
       "name": "Thomas Was Alone",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        9,
+        14,
+        34,
+        39,
+        41,
+        46,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -58173,6 +60531,17 @@
       ],
       "name": "Toki Tori",
       "parent_game": 194909,
+      "platforms": [
+        3,
+        5,
+        6,
+        9,
+        14,
+        34,
+        39,
+        41,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -58263,6 +60632,9 @@
       ],
       "name": "Mario Party",
       "parent_game": -1,
+      "platforms": [
+        4
+      ],
       "player_perspectives": [
         3
       ],
@@ -58363,6 +60735,13 @@
       ],
       "name": "Super Mario Kart",
       "parent_game": -1,
+      "platforms": [
+        5,
+        19,
+        41,
+        58,
+        137
+      ],
       "player_perspectives": [
         2
       ],
@@ -58450,6 +60829,9 @@
       ],
       "name": "Mario Party 9",
       "parent_game": -1,
+      "platforms": [
+        5
+      ],
       "player_perspectives": [
         2
       ],
@@ -58563,6 +60945,11 @@
       ],
       "name": "Mario Kart 64",
       "parent_game": -1,
+      "platforms": [
+        4,
+        5,
+        41
+      ],
       "player_perspectives": [
         2
       ],
@@ -58666,6 +61053,11 @@
       ],
       "name": "Mario Kart: Super Circuit",
       "parent_game": -1,
+      "platforms": [
+        24,
+        37,
+        41
+      ],
       "player_perspectives": [
         2
       ],
@@ -58740,6 +61132,9 @@
       ],
       "name": "Mario Kart: Double Dash!!",
       "parent_game": -1,
+      "platforms": [
+        21
+      ],
       "player_perspectives": [
         2
       ],
@@ -58862,6 +61257,10 @@
       ],
       "name": "Mario Kart DS",
       "parent_game": -1,
+      "platforms": [
+        20,
+        41
+      ],
       "player_perspectives": [
         2
       ],
@@ -58965,6 +61364,9 @@
       ],
       "name": "Mario Kart 7",
       "parent_game": -1,
+      "platforms": [
+        37
+      ],
       "player_perspectives": [
         2
       ],
@@ -59082,6 +61484,9 @@
       ],
       "name": "Mario Kart 8",
       "parent_game": -1,
+      "platforms": [
+        41
+      ],
       "player_perspectives": [
         2
       ],
@@ -59176,6 +61581,10 @@
       ],
       "name": "Deadlight",
       "parent_game": -1,
+      "platforms": [
+        6,
+        12
+      ],
       "player_perspectives": [
         4
       ],
@@ -59238,6 +61647,18 @@
       "keywords": [],
       "name": "Puzzle Quest: Challenge of the Warlords",
       "parent_game": -1,
+      "platforms": [
+        5,
+        6,
+        8,
+        9,
+        12,
+        20,
+        38,
+        39,
+        48,
+        159
+      ],
       "player_perspectives": [
         3,
         4
@@ -59332,6 +61753,11 @@
       ],
       "name": "Oni",
       "parent_game": -1,
+      "platforms": [
+        6,
+        8,
+        14
+      ],
       "player_perspectives": [
         2
       ],
@@ -59460,6 +61886,14 @@
       ],
       "name": "Prince of Persia: The Two Thrones",
       "parent_game": -1,
+      "platforms": [
+        6,
+        8,
+        9,
+        11,
+        14,
+        21
+      ],
       "player_perspectives": [
         2
       ],
@@ -59537,6 +61971,12 @@
       "name": "Prince of Persia",
       "name_glogAppendReleaseYear": true,
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        14
+      ],
       "player_perspectives": [
         2
       ],
@@ -59668,6 +62108,11 @@
       ],
       "name": "Quantum Conundrum",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         1
       ],
@@ -59777,6 +62222,11 @@
       ],
       "name": "Prince of Persia: The Forgotten Sands",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -59913,6 +62363,12 @@
       ],
       "name": "Torchlight",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        12,
+        14
+      ],
       "player_perspectives": [
         3
       ],
@@ -59996,6 +62452,9 @@
       ],
       "name": "Luigi's Mansion",
       "parent_game": -1,
+      "platforms": [
+        21
+      ],
       "player_perspectives": [
         2
       ],
@@ -60066,6 +62525,11 @@
       ],
       "name": "Enslaved: Odyssey to the West",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -60131,6 +62595,12 @@
       ],
       "name": "Alpha Protocol",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -60224,6 +62694,13 @@
       "name": "Mad Max",
       "name_glogAppendReleaseYear": true,
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        48,
+        49
+      ],
       "player_perspectives": [
         2
       ],
@@ -60336,6 +62813,11 @@
       ],
       "name": "Star Fox 64",
       "parent_game": -1,
+      "platforms": [
+        4,
+        5,
+        41
+      ],
       "player_perspectives": [
         1,
         2
@@ -60452,6 +62934,18 @@
       ],
       "name": "Altered Beast",
       "parent_game": -1,
+      "platforms": [
+        5,
+        13,
+        15,
+        16,
+        25,
+        26,
+        27,
+        39,
+        52,
+        63
+      ],
       "player_perspectives": [
         4
       ],
@@ -60565,6 +63059,12 @@
       ],
       "name": "BattleBlock Theater",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        12,
+        14
+      ],
       "player_perspectives": [
         4
       ],
@@ -60647,6 +63147,11 @@
       ],
       "name": "BloodRayne: Betrayal",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         4
       ],
@@ -60744,6 +63249,10 @@
       ],
       "name": "Sonic Lost World",
       "parent_game": -1,
+      "platforms": [
+        6,
+        41
+      ],
       "player_perspectives": [
         2,
         4
@@ -60798,6 +63307,9 @@
       "keywords": [],
       "name": "Excite Truck",
       "parent_game": -1,
+      "platforms": [
+        5
+      ],
       "player_perspectives": [
         2
       ],
@@ -60871,6 +63383,9 @@
       ],
       "name": "The Wonderful 101",
       "parent_game": -1,
+      "platforms": [
+        41
+      ],
       "player_perspectives": [
         3
       ],
@@ -60950,6 +63465,11 @@
       ],
       "name": "Halo: Combat Evolved Anniversary",
       "parent_game": 740,
+      "platforms": [
+        6,
+        12,
+        49
+      ],
       "player_perspectives": [
         1
       ],
@@ -61086,6 +63606,10 @@
       ],
       "name": "Animal Crossing: Wild World",
       "parent_game": -1,
+      "platforms": [
+        20,
+        41
+      ],
       "player_perspectives": [
         3
       ],
@@ -61144,6 +63668,9 @@
       ],
       "name": "Animal Crossing",
       "parent_game": 44042,
+      "platforms": [
+        21
+      ],
       "player_perspectives": [
         3
       ],
@@ -61257,6 +63784,14 @@
       ],
       "name": "Guitar Hero III: Legends of Rock",
       "parent_game": -1,
+      "platforms": [
+        5,
+        6,
+        8,
+        9,
+        12,
+        14
+      ],
       "player_perspectives": [
         6
       ],
@@ -61378,6 +63913,13 @@
       ],
       "name": "LEGO Star Wars: The Video Game",
       "parent_game": -1,
+      "platforms": [
+        6,
+        8,
+        11,
+        14,
+        21
+      ],
       "player_perspectives": [
         2
       ],
@@ -61508,6 +64050,10 @@
       ],
       "name": "Mercenaries: Playground of Destruction",
       "parent_game": -1,
+      "platforms": [
+        8,
+        11
+      ],
       "player_perspectives": [
         2
       ],
@@ -61612,6 +64158,12 @@
       ],
       "name": "Rock Band",
       "parent_game": -1,
+      "platforms": [
+        5,
+        8,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -61708,6 +64260,9 @@
       ],
       "name": "Star Fox Adventures",
       "parent_game": 134251,
+      "platforms": [
+        21
+      ],
       "player_perspectives": [
         2
       ],
@@ -61808,6 +64363,11 @@
       ],
       "name": "Alien Hominid",
       "parent_game": 314892,
+      "platforms": [
+        8,
+        11,
+        21
+      ],
       "player_perspectives": [
         4
       ],
@@ -61917,6 +64477,12 @@
       ],
       "name": "Rock Band 2",
       "parent_game": -1,
+      "platforms": [
+        5,
+        8,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -61989,6 +64555,10 @@
       ],
       "name": "Brain Age: Train Your Brain in Minutes a Day!",
       "parent_game": -1,
+      "platforms": [
+        20,
+        41
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -62049,6 +64619,9 @@
       ],
       "name": "Tetris Attack",
       "parent_game": 84157,
+      "platforms": [
+        19
+      ],
       "player_perspectives": [
         4
       ],
@@ -62117,6 +64690,9 @@
       ],
       "name": "Elebits",
       "parent_game": -1,
+      "platforms": [
+        5
+      ],
       "player_perspectives": [
         1
       ],
@@ -62167,6 +64743,10 @@
       "keywords": [],
       "name": "Adventure Time: Hey Ice King! Why'd You Steal Our Garbage?!",
       "parent_game": -1,
+      "platforms": [
+        20,
+        37
+      ],
       "player_perspectives": [
         4
       ],
@@ -62272,6 +64852,13 @@
       ],
       "name": "Braid",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        9,
+        12,
+        14
+      ],
       "player_perspectives": [
         4
       ],
@@ -62336,6 +64923,9 @@
       ],
       "name": "Crackdown",
       "parent_game": -1,
+      "platforms": [
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -62395,6 +64985,9 @@
       ],
       "name": "Crackdown 2",
       "parent_game": -1,
+      "platforms": [
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -62520,6 +65113,12 @@
       ],
       "name": "EarthBound",
       "parent_game": -1,
+      "platforms": [
+        19,
+        41,
+        58,
+        137
+      ],
       "player_perspectives": [
         1,
         3
@@ -62635,6 +65234,9 @@
       ],
       "name": "The Legend of Zelda: A Link Between Worlds",
       "parent_game": -1,
+      "platforms": [
+        37
+      ],
       "player_perspectives": [
         2,
         3
@@ -62741,6 +65343,11 @@
       ],
       "name": "Crusader Kings II",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         3
       ],
@@ -62829,6 +65436,9 @@
       ],
       "name": "Donkey Kong Country: Tropical Freeze",
       "parent_game": -1,
+      "platforms": [
+        41
+      ],
       "player_perspectives": [
         4
       ],
@@ -62900,6 +65510,14 @@
       ],
       "name": "Papers, Please",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        34,
+        39,
+        46
+      ],
       "player_perspectives": [
         1,
         5
@@ -63012,6 +65630,12 @@
       ],
       "name": "The Vanishing of Ethan Carter",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         1
       ],
@@ -63061,6 +65685,12 @@
       "keywords": [],
       "name": "Killer Is Dead",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        49
+      ],
       "player_perspectives": [],
       "ports": [
         23353
@@ -63143,6 +65773,9 @@
       ],
       "name": "Audiosurf",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [
         2
       ],
@@ -63265,6 +65898,11 @@
       ],
       "name": "Dota 2",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         2,
         3
@@ -63323,6 +65961,11 @@
       ],
       "name": "The Lord of the Rings: The Two Towers",
       "parent_game": -1,
+      "platforms": [
+        8,
+        11,
+        21
+      ],
       "player_perspectives": [
         2
       ],
@@ -63430,6 +66073,14 @@
       ],
       "name": "The Lord of the Rings: The Return of the King",
       "parent_game": -1,
+      "platforms": [
+        6,
+        8,
+        11,
+        14,
+        21,
+        55
+      ],
       "player_perspectives": [
         2
       ],
@@ -63500,6 +66151,11 @@
       ],
       "name": "Space Pirates and Zombies",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         3
       ],
@@ -63576,6 +66232,18 @@
       ],
       "name": "Machinarium",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        9,
+        14,
+        34,
+        39,
+        46,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -63654,6 +66322,14 @@
       ],
       "name": "Superbrothers: Sword & Sworcery EP",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        34,
+        39,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -63711,6 +66387,11 @@
       ],
       "name": "The Elder Scrolls V: Skyrim - Dawnguard",
       "parent_game": 472,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         1,
         2
@@ -63837,6 +66518,17 @@
       ],
       "name": "The Wolf Among Us",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        14,
+        34,
+        39,
+        46,
+        48,
+        49
+      ],
       "player_perspectives": [
         2,
         3
@@ -63911,6 +66603,11 @@
       ],
       "name": "DLC Quest",
       "parent_game": -1,
+      "platforms": [
+        6,
+        12,
+        14
+      ],
       "player_perspectives": [
         4
       ],
@@ -64056,6 +66753,9 @@
       ],
       "name": "Banjo-Kazooie: Nuts & Bolts",
       "parent_game": -1,
+      "platforms": [
+        12
+      ],
       "player_perspectives": [
         1,
         2,
@@ -64218,6 +66918,16 @@
       ],
       "name": "Unepic",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        41,
+        46,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -64343,6 +67053,18 @@
       ],
       "name": "Shadowrun Returns",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        34,
+        39,
+        48,
+        49,
+        130,
+        167,
+        169
+      ],
       "player_perspectives": [
         3
       ],
@@ -64434,6 +67156,14 @@
       ],
       "name": "Transistor",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        39,
+        48,
+        130
+      ],
       "player_perspectives": [
         3,
         4
@@ -64586,6 +67316,15 @@
       ],
       "name": "Middle-earth: Shadow of Mordor",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        9,
+        12,
+        14,
+        48,
+        49
+      ],
       "player_perspectives": [
         2
       ],
@@ -64679,6 +67418,12 @@
       ],
       "name": "Capsized",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        12,
+        14
+      ],
       "player_perspectives": [
         4
       ],
@@ -64747,6 +67492,9 @@
       ],
       "name": "Rampage",
       "parent_game": -1,
+      "platforms": [
+        52
+      ],
       "player_perspectives": [
         4
       ],
@@ -64844,6 +67592,10 @@
       ],
       "name": "Wet",
       "parent_game": -1,
+      "platforms": [
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -64937,6 +67689,11 @@
       ],
       "name": "Euro Truck Simulator 2",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         1,
         2,
@@ -65039,6 +67796,12 @@
       ],
       "name": "FTL: Faster Than Light",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        39
+      ],
       "player_perspectives": [
         3
       ],
@@ -65085,6 +67848,13 @@
       "keywords": [],
       "name": "About Love, Hate and the other ones",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        34,
+        39
+      ],
       "player_perspectives": [
         4
       ],
@@ -65166,6 +67936,9 @@
       ],
       "name": "Evil Genius",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [
         3
       ],
@@ -65237,6 +68010,12 @@
       ],
       "name": "Dear Esther",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14,
+        48,
+        49
+      ],
       "player_perspectives": [
         1
       ],
@@ -65346,6 +68125,18 @@
       ],
       "name": "Broken Age",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        34,
+        39,
+        46,
+        48,
+        49,
+        72,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -65421,6 +68212,14 @@
       ],
       "name": "Door Kickers",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        34,
+        39,
+        130
+      ],
       "player_perspectives": [
         3
       ],
@@ -65521,6 +68320,13 @@
       ],
       "name": "Wasteland 2",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        48,
+        49
+      ],
       "player_perspectives": [
         3
       ],
@@ -65596,6 +68402,15 @@
       ],
       "name": "Kerbal Space Program",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        41,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         1,
         2,
@@ -65696,6 +68511,14 @@
       ],
       "name": "Don't Starve",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         3
       ],
@@ -65889,6 +68712,12 @@
       ],
       "name": "Castle Crashers",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        14
+      ],
       "player_perspectives": [
         4
       ],
@@ -65975,6 +68804,10 @@
       ],
       "name": "World of Warcraft: Warlords of Draenor",
       "parent_game": 123,
+      "platforms": [
+        6,
+        14
+      ],
       "player_perspectives": [
         1,
         2
@@ -66100,6 +68933,11 @@
       ],
       "name": "The Saboteur",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -66171,6 +69009,11 @@
       ],
       "name": "Grand Theft Auto IV: The Ballad of Gay Tony",
       "parent_game": 731,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -66246,6 +69089,14 @@
       ],
       "name": "Diablo III: Reaper of Souls",
       "parent_game": 120,
+      "platforms": [
+        6,
+        9,
+        12,
+        14,
+        48,
+        49
+      ],
       "player_perspectives": [
         3
       ],
@@ -66403,6 +69254,13 @@
       ],
       "name": "Murdered: Soul Suspect",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        48,
+        49
+      ],
       "player_perspectives": [
         2
       ],
@@ -66535,6 +69393,15 @@
       ],
       "name": "Sonic the Hedgehog",
       "parent_game": -1,
+      "platforms": [
+        5,
+        6,
+        9,
+        12,
+        29,
+        39,
+        52
+      ],
       "player_perspectives": [
         4
       ],
@@ -66687,6 +69554,9 @@
       ],
       "name": "MadWorld",
       "parent_game": -1,
+      "platforms": [
+        5
+      ],
       "player_perspectives": [
         2
       ],
@@ -66805,6 +69675,15 @@
       ],
       "name": "Secret of Mana",
       "parent_game": -1,
+      "platforms": [
+        5,
+        19,
+        34,
+        39,
+        41,
+        58,
+        131
+      ],
       "player_perspectives": [
         3
       ],
@@ -66931,6 +69810,13 @@
       ],
       "name": "Vanquish",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        48,
+        49
+      ],
       "player_perspectives": [
         2
       ],
@@ -67080,6 +69966,16 @@
       ],
       "name": "Rogue Legacy",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        9,
+        14,
+        46,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -67159,6 +70055,15 @@
       ],
       "name": "Chasm",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        46,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -67253,6 +70158,18 @@
       ],
       "name": "No Man's Sky",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14,
+        48,
+        49,
+        163,
+        165,
+        167,
+        169,
+        385,
+        390
+      ],
       "player_perspectives": [
         1,
         2,
@@ -67356,6 +70273,11 @@
       ],
       "name": "Gunpoint",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         4
       ],
@@ -67436,6 +70358,9 @@
       ],
       "name": "Star Fox: Assault",
       "parent_game": -1,
+      "platforms": [
+        21
+      ],
       "player_perspectives": [
         2
       ],
@@ -67567,6 +70492,11 @@
       ],
       "name": "Grand Theft Auto: Vice City Stories",
       "parent_game": -1,
+      "platforms": [
+        8,
+        9,
+        38
+      ],
       "player_perspectives": [
         2
       ],
@@ -67697,6 +70627,9 @@
       ],
       "name": "Grand Theft Auto: Liberty City Stories",
       "parent_game": -1,
+      "platforms": [
+        38
+      ],
       "player_perspectives": [
         2
       ],
@@ -67768,6 +70701,11 @@
       ],
       "name": "Grand Theft Auto IV: The Lost and Damned",
       "parent_game": 731,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -67902,6 +70840,12 @@
       ],
       "name": "Grand Theft Auto: Chinatown Wars",
       "parent_game": -1,
+      "platforms": [
+        20,
+        34,
+        38,
+        39
+      ],
       "player_perspectives": [
         3
       ],
@@ -67986,6 +70930,11 @@
       ],
       "name": "Sid Meier's Civilization V: Gods & Kings",
       "parent_game": 866,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         3
       ],
@@ -68049,6 +70998,11 @@
       ],
       "name": "Sid Meier's Civilization V: Brave New World",
       "parent_game": 866,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         3
       ],
@@ -68173,6 +71127,11 @@
       ],
       "name": "Paper Mario",
       "parent_game": -1,
+      "platforms": [
+        4,
+        5,
+        41
+      ],
       "player_perspectives": [
         2,
         4
@@ -68329,6 +71288,9 @@
       ],
       "name": "Paper Mario: The Thousand-Year Door",
       "parent_game": -1,
+      "platforms": [
+        21
+      ],
       "player_perspectives": [
         2
       ],
@@ -68415,6 +71377,9 @@
       ],
       "name": "Paper Mario: Sticker Star",
       "parent_game": -1,
+      "platforms": [
+        37
+      ],
       "player_perspectives": [
         2
       ],
@@ -68528,6 +71493,10 @@
       ],
       "name": "Mario & Luigi: Superstar Saga",
       "parent_game": -1,
+      "platforms": [
+        24,
+        41
+      ],
       "player_perspectives": [
         4
       ],
@@ -68644,6 +71613,9 @@
       ],
       "name": "Mario & Luigi: Bowser's Inside Story",
       "parent_game": -1,
+      "platforms": [
+        20
+      ],
       "player_perspectives": [
         3,
         4
@@ -68777,6 +71749,10 @@
       ],
       "name": "Mario & Luigi: Partners in Time",
       "parent_game": -1,
+      "platforms": [
+        20,
+        41
+      ],
       "player_perspectives": [
         4
       ],
@@ -68915,6 +71891,9 @@
       ],
       "name": "Mario & Luigi: Dream Team",
       "parent_game": -1,
+      "platforms": [
+        37
+      ],
       "player_perspectives": [
         3,
         4
@@ -69033,6 +72012,9 @@
       ],
       "name": "Banjo-Tooie",
       "parent_game": -1,
+      "platforms": [
+        4
+      ],
       "player_perspectives": [
         2
       ],
@@ -69106,6 +72088,9 @@
       ],
       "name": "Blast Corps",
       "parent_game": -1,
+      "platforms": [
+        4
+      ],
       "player_perspectives": [
         2
       ],
@@ -69167,6 +72152,12 @@
       ],
       "name": "Super Bomberman",
       "parent_game": -1,
+      "platforms": [
+        19,
+        55,
+        58,
+        306
+      ],
       "player_perspectives": [
         3
       ],
@@ -69229,6 +72220,9 @@
       ],
       "name": "Extreme-G",
       "parent_game": -1,
+      "platforms": [
+        4
+      ],
       "player_perspectives": [
         2
       ],
@@ -69313,6 +72307,11 @@
       ],
       "name": "F-Zero X",
       "parent_game": -1,
+      "platforms": [
+        4,
+        5,
+        41
+      ],
       "player_perspectives": [
         2
       ],
@@ -69407,6 +72406,15 @@
       ],
       "name": "F-Zero",
       "parent_game": -1,
+      "platforms": [
+        5,
+        19,
+        41,
+        52,
+        58,
+        137,
+        306
+      ],
       "player_perspectives": [
         2
       ],
@@ -69503,6 +72511,9 @@
       ],
       "name": "F-Zero GX",
       "parent_game": -1,
+      "platforms": [
+        21
+      ],
       "player_perspectives": [
         2
       ],
@@ -69580,6 +72591,12 @@
       ],
       "name": "Gauntlet Legends",
       "parent_game": -1,
+      "platforms": [
+        4,
+        7,
+        23,
+        52
+      ],
       "player_perspectives": [
         3
       ],
@@ -69679,6 +72696,21 @@
       ],
       "name": "Gauntlet",
       "parent_game": -1,
+      "platforms": [
+        12,
+        13,
+        14,
+        15,
+        25,
+        26,
+        27,
+        52,
+        63,
+        64,
+        65,
+        75,
+        115
+      ],
       "player_perspectives": [
         3
       ],
@@ -69764,6 +72796,10 @@
       ],
       "name": "Pokémon Puzzle League",
       "parent_game": -1,
+      "platforms": [
+        4,
+        5
+      ],
       "player_perspectives": [
         4
       ],
@@ -69843,6 +72879,22 @@
       ],
       "name": "Robotron: 2084",
       "parent_game": -1,
+      "platforms": [
+        12,
+        13,
+        14,
+        15,
+        52,
+        60,
+        61,
+        63,
+        65,
+        66,
+        69,
+        71,
+        75,
+        134
+      ],
       "player_perspectives": [
         3
       ],
@@ -69932,6 +72984,10 @@
       ],
       "name": "Wave Race 64",
       "parent_game": -1,
+      "platforms": [
+        4,
+        41
+      ],
       "player_perspectives": [
         1,
         2
@@ -70011,6 +73067,10 @@
       ],
       "name": "Dance Dance Revolution",
       "parent_game": -1,
+      "platforms": [
+        7,
+        52
+      ],
       "player_perspectives": [
         6
       ],
@@ -70106,6 +73166,12 @@
       ],
       "name": "Kirby & the Amazing Mirror",
       "parent_game": -1,
+      "platforms": [
+        5,
+        24,
+        37,
+        41
+      ],
       "player_perspectives": [
         4
       ],
@@ -70177,6 +73243,10 @@
       ],
       "name": "Kirby: Canvas Curse",
       "parent_game": -1,
+      "platforms": [
+        20,
+        41
+      ],
       "player_perspectives": [
         4
       ],
@@ -70245,6 +73315,10 @@
       ],
       "name": "Kirby: Squeak Squad",
       "parent_game": -1,
+      "platforms": [
+        20,
+        41
+      ],
       "player_perspectives": [
         4
       ],
@@ -70342,6 +73416,10 @@
       ],
       "name": "Kirby Mass Attack",
       "parent_game": -1,
+      "platforms": [
+        20,
+        41
+      ],
       "player_perspectives": [
         4
       ],
@@ -70412,6 +73490,10 @@
       ],
       "name": "Red Dead Redemption: Undead Nightmare",
       "parent_game": 434,
+      "platforms": [
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -70519,6 +73601,10 @@
       ],
       "name": "Quantum Break",
       "parent_game": -1,
+      "platforms": [
+        6,
+        49
+      ],
       "player_perspectives": [
         2
       ],
@@ -70588,6 +73674,14 @@
       ],
       "name": "Assassin's Creed: Freedom Cry",
       "parent_game": 1970,
+      "platforms": [
+        6,
+        9,
+        12,
+        48,
+        49,
+        170
+      ],
       "player_perspectives": [
         2
       ],
@@ -70676,6 +73770,9 @@
       ],
       "name": "Baten Kaitos: Eternal Wings and the Lost Ocean",
       "parent_game": -1,
+      "platforms": [
+        21
+      ],
       "player_perspectives": [
         2
       ],
@@ -70739,6 +73836,9 @@
       ],
       "name": "Battalion Wars",
       "parent_game": -1,
+      "platforms": [
+        21
+      ],
       "player_perspectives": [
         2
       ],
@@ -70809,6 +73909,13 @@
       ],
       "name": "Contrast",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        48,
+        49
+      ],
       "player_perspectives": [
         2
       ],
@@ -70887,6 +73994,9 @@
       ],
       "name": "Chibi-Robo!",
       "parent_game": -1,
+      "platforms": [
+        21
+      ],
       "player_perspectives": [
         2
       ],
@@ -70944,6 +74054,9 @@
       ],
       "name": "Eternal Darkness: Sanity's Requiem",
       "parent_game": -1,
+      "platforms": [
+        21
+      ],
       "player_perspectives": [
         2
       ],
@@ -71000,6 +74113,13 @@
       ],
       "name": "Future Tactics: The Uprising",
       "parent_game": -1,
+      "platforms": [
+        6,
+        8,
+        11,
+        21,
+        474
+      ],
       "player_perspectives": [
         2
       ],
@@ -71080,6 +74200,9 @@
       ],
       "name": "Geist",
       "parent_game": -1,
+      "platforms": [
+        21
+      ],
       "player_perspectives": [
         1
       ],
@@ -71138,6 +74261,12 @@
       ],
       "name": "I-Ninja",
       "parent_game": -1,
+      "platforms": [
+        6,
+        8,
+        11,
+        21
+      ],
       "player_perspectives": [
         2
       ],
@@ -71223,6 +74352,9 @@
       ],
       "name": "Ikaruga",
       "parent_game": -1,
+      "platforms": [
+        52
+      ],
       "player_perspectives": [
         2,
         3
@@ -71343,6 +74475,11 @@
       ],
       "name": "Killer7",
       "parent_game": -1,
+      "platforms": [
+        6,
+        8,
+        21
+      ],
       "player_perspectives": [
         1
       ],
@@ -71433,6 +74570,9 @@
       ],
       "name": "Valkyrie Profile",
       "parent_game": -1,
+      "platforms": [
+        7
+      ],
       "player_perspectives": [
         2,
         4
@@ -71486,6 +74626,9 @@
       ],
       "name": "Metal Gear Solid: The Twin Snakes",
       "parent_game": 375,
+      "platforms": [
+        21
+      ],
       "player_perspectives": [
         2
       ],
@@ -71539,6 +74682,9 @@
       ],
       "name": "P.N.03",
       "parent_game": -1,
+      "platforms": [
+        21
+      ],
       "player_perspectives": [
         2
       ],
@@ -71599,6 +74745,11 @@
       ],
       "name": "Vexx",
       "parent_game": -1,
+      "platforms": [
+        8,
+        11,
+        21
+      ],
       "player_perspectives": [
         2
       ],
@@ -71660,6 +74811,11 @@
       ],
       "name": "Robotech: Battlecry",
       "parent_game": -1,
+      "platforms": [
+        8,
+        11,
+        21
+      ],
       "player_perspectives": [
         1,
         2
@@ -71745,6 +74901,12 @@
       ],
       "name": "Second Sight",
       "parent_game": -1,
+      "platforms": [
+        6,
+        8,
+        11,
+        21
+      ],
       "player_perspectives": [
         1,
         2
@@ -71839,6 +75001,10 @@
       ],
       "name": "Skies of Arcadia Legends",
       "parent_game": 19007,
+      "platforms": [
+        8,
+        21
+      ],
       "player_perspectives": [
         2
       ],
@@ -71940,6 +75106,12 @@
       ],
       "name": "Sonic Heroes",
       "parent_game": -1,
+      "platforms": [
+        6,
+        8,
+        11,
+        21
+      ],
       "player_perspectives": [
         2,
         3
@@ -72015,6 +75187,12 @@
       ],
       "name": "Sonic Mega Collection",
       "parent_game": -1,
+      "platforms": [
+        6,
+        8,
+        11,
+        21
+      ],
       "player_perspectives": [
         2,
         3,
@@ -72079,6 +75257,14 @@
       ],
       "name": "Sphinx and the Cursed Mummy",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        8,
+        11,
+        14,
+        21
+      ],
       "player_perspectives": [
         2
       ],
@@ -72149,6 +75335,12 @@
       ],
       "name": "Star Wars: Bounty Hunter",
       "parent_game": -1,
+      "platforms": [
+        8,
+        9,
+        21,
+        48
+      ],
       "player_perspectives": [
         2
       ],
@@ -72231,6 +75423,9 @@
       ],
       "name": "Star Wars: Rogue Squadron II - Rogue Leader",
       "parent_game": -1,
+      "platforms": [
+        21
+      ],
       "player_perspectives": [
         2
       ],
@@ -72316,6 +75511,9 @@
       ],
       "name": "Star Wars: Rogue Squadron III - Rebel Strike",
       "parent_game": -1,
+      "platforms": [
+        21
+      ],
       "player_perspectives": [
         2
       ],
@@ -72414,6 +75612,12 @@
       ],
       "name": "Terminator Salvation",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        39
+      ],
       "player_perspectives": [
         2
       ],
@@ -72505,6 +75709,11 @@
       ],
       "name": "Darkest of Days",
       "parent_game": -1,
+      "platforms": [
+        6,
+        12,
+        14
+      ],
       "player_perspectives": [
         1
       ],
@@ -72563,6 +75772,11 @@
       ],
       "name": "Dark Void",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -72622,6 +75836,9 @@
       ],
       "name": "Universal Studios Theme Parks Adventure",
       "parent_game": -1,
+      "platforms": [
+        21
+      ],
       "player_perspectives": [
         2
       ],
@@ -72683,6 +75900,10 @@
       ],
       "name": "Viewtiful Joe",
       "parent_game": -1,
+      "platforms": [
+        8,
+        21
+      ],
       "player_perspectives": [
         4
       ],
@@ -72758,6 +75979,10 @@
       ],
       "name": "Viewtiful Joe 2",
       "parent_game": -1,
+      "platforms": [
+        8,
+        21
+      ],
       "player_perspectives": [
         4
       ],
@@ -72842,6 +76067,12 @@
       ],
       "name": "Lemmings",
       "parent_game": -1,
+      "platforms": [
+        16,
+        114,
+        116,
+        158
+      ],
       "player_perspectives": [
         4
       ],
@@ -72994,6 +76225,15 @@
       ],
       "name": "Sonic the Hedgehog 2",
       "parent_game": -1,
+      "platforms": [
+        5,
+        6,
+        9,
+        12,
+        29,
+        37,
+        41
+      ],
       "player_perspectives": [
         4
       ],
@@ -73120,6 +76360,13 @@
       ],
       "name": "Dr. Robotnik's Mean Bean Machine",
       "parent_game": 47250,
+      "platforms": [
+        3,
+        5,
+        6,
+        14,
+        29
+      ],
       "player_perspectives": [
         4
       ],
@@ -73201,6 +76448,13 @@
       ],
       "name": "Adventure Time: Explore the Dungeon Because I Don't Know!",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        37,
+        41
+      ],
       "player_perspectives": [
         2,
         3
@@ -73289,6 +76543,11 @@
       ],
       "name": "X-Men Legends",
       "parent_game": -1,
+      "platforms": [
+        8,
+        11,
+        21
+      ],
       "player_perspectives": [
         2
       ],
@@ -73348,6 +76607,19 @@
       "name": "A Boy and His Blob",
       "name_glogAppendReleaseYear": true,
       "parent_game": 2109,
+      "platforms": [
+        3,
+        5,
+        6,
+        9,
+        14,
+        34,
+        39,
+        46,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -73418,6 +76690,10 @@
       ],
       "name": "Alien Syndrome",
       "parent_game": 4478,
+      "platforms": [
+        5,
+        38
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -73499,6 +76775,9 @@
       ],
       "name": "Battalion Wars 2",
       "parent_game": -1,
+      "platforms": [
+        5
+      ],
       "player_perspectives": [
         2
       ],
@@ -73578,6 +76857,16 @@
       ],
       "name": "Child of Light",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        41,
+        46,
+        48,
+        49,
+        170
+      ],
       "player_perspectives": [
         4
       ],
@@ -73703,6 +76992,10 @@
       ],
       "name": "D4: Dark Dreams Don't Die - Season 1",
       "parent_game": -1,
+      "platforms": [
+        6,
+        49
+      ],
       "player_perspectives": [
         2
       ],
@@ -73793,6 +77086,10 @@
       ],
       "name": "The Conduit",
       "parent_game": -1,
+      "platforms": [
+        5,
+        34
+      ],
       "player_perspectives": [
         1
       ],
@@ -73944,6 +77241,12 @@
       ],
       "name": "Dead Rising",
       "parent_game": -1,
+      "platforms": [
+        6,
+        12,
+        48,
+        49
+      ],
       "player_perspectives": [
         2
       ],
@@ -74044,6 +77347,9 @@
       ],
       "name": "Dead Rising: Chop Till You Drop",
       "parent_game": 4797,
+      "platforms": [
+        5
+      ],
       "player_perspectives": [
         2
       ],
@@ -74099,6 +77405,10 @@
       ],
       "name": "Dokapon Kingdom",
       "parent_game": -1,
+      "platforms": [
+        5,
+        8
+      ],
       "player_perspectives": [
         2
       ],
@@ -74161,6 +77471,10 @@
       ],
       "name": "Drawn to Life",
       "parent_game": -1,
+      "platforms": [
+        20,
+        39
+      ],
       "player_perspectives": [
         3
       ],
@@ -74209,6 +77523,9 @@
       ],
       "name": "Emergency Heroes",
       "parent_game": -1,
+      "platforms": [
+        5
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -74276,6 +77593,14 @@
       ],
       "name": "Halo: Spartan Assault",
       "parent_game": -1,
+      "platforms": [
+        6,
+        12,
+        39,
+        49,
+        55,
+        74
+      ],
       "player_perspectives": [
         2,
         3
@@ -74373,6 +77698,17 @@
       ],
       "name": "LEGO The Hobbit",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        14,
+        37,
+        41,
+        46,
+        48,
+        49
+      ],
       "player_perspectives": [
         2
       ],
@@ -74470,6 +77806,16 @@
       ],
       "name": "The LEGO Movie Videogame",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        37,
+        41,
+        46,
+        48,
+        49
+      ],
       "player_perspectives": [
         2
       ],
@@ -74595,6 +77941,13 @@
       ],
       "name": "Stacking",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        9,
+        12,
+        14
+      ],
       "player_perspectives": [
         2
       ],
@@ -74647,6 +78000,9 @@
       "keywords": [],
       "name": "Geometry Wars",
       "parent_game": -1,
+      "platforms": [
+        11
+      ],
       "player_perspectives": [
         3
       ],
@@ -74711,6 +78067,11 @@
       ],
       "name": "Harvey Birdman: Attorney at Law",
       "parent_game": -1,
+      "platforms": [
+        5,
+        8,
+        38
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -74837,6 +78198,9 @@
       ],
       "name": "The House of the Dead: Overkill",
       "parent_game": -1,
+      "platforms": [
+        5
+      ],
       "player_perspectives": [
         1
       ],
@@ -74901,6 +78265,11 @@
       ],
       "name": "Jumper: Griffin's Story",
       "parent_game": -1,
+      "platforms": [
+        5,
+        8,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -74965,6 +78334,12 @@
       ],
       "name": "Jurassic: The Hunted",
       "parent_game": -1,
+      "platforms": [
+        5,
+        8,
+        9,
+        12
+      ],
       "player_perspectives": [
         1
       ],
@@ -75062,6 +78437,14 @@
       ],
       "name": "LEGO The Lord of the Rings",
       "parent_game": -1,
+      "platforms": [
+        5,
+        6,
+        9,
+        12,
+        14,
+        39
+      ],
       "player_perspectives": [
         2
       ],
@@ -75140,6 +78523,9 @@
       ],
       "name": "Link's Crossbow Training",
       "parent_game": -1,
+      "platforms": [
+        5
+      ],
       "player_perspectives": [
         1
       ],
@@ -75169,7 +78555,7 @@
       "dlcs": [],
       "expanded_games": [],
       "expansions": [],
-      "first_release_date": 1164844800,
+      "first_release_date": 1166054400,
       "forks": [],
       "franchise": -1,
       "franchises": [],
@@ -75183,10 +78569,11 @@
       ],
       "id": 5004,
       "involved_companies": [
-        12074,
-        12075,
-        12076,
-        12077
+        290288,
+        290289,
+        290290,
+        290291,
+        290292
       ],
       "keywords": [
         1,
@@ -75198,6 +78585,7 @@
         960,
         1107,
         1186,
+        1679,
         1705,
         1821,
         2152,
@@ -75223,25 +78611,37 @@
       ],
       "name": "Metal Slug Anthology",
       "parent_game": -1,
+      "platforms": [
+        5,
+        8,
+        38,
+        48
+      ],
       "player_perspectives": [
         4
       ],
       "ports": [],
       "release_dates": [
-        11618,
-        11619,
-        11621,
-        53234,
-        141308,
-        141309,
-        141310
+        649698,
+        649699,
+        649700,
+        649702,
+        649703,
+        649704,
+        650498,
+        650499,
+        650539,
+        650540,
+        650541,
+        650542
       ],
       "remakes": [],
       "remasters": [],
       "standalone_expansions": [],
       "themes": [
         1,
-        27
+        27,
+        39
       ],
       "url": "https://www.igdb.com/games/metal-slug-anthology",
       "version_parent": -1
@@ -75325,6 +78725,16 @@
       ],
       "name": "To the Moon",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        34,
+        39,
+        130,
+        167,
+        169
+      ],
       "player_perspectives": [
         3
       ],
@@ -75442,6 +78852,10 @@
       ],
       "name": "Divinity: Original Sin",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14
+      ],
       "player_perspectives": [
         3
       ],
@@ -75503,6 +78917,10 @@
       ],
       "name": "Sonic Unleashed",
       "parent_game": -1,
+      "platforms": [
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -75584,6 +79002,16 @@
       ],
       "name": "Tiger Woods PGA Tour 08",
       "parent_game": -1,
+      "platforms": [
+        5,
+        6,
+        8,
+        9,
+        12,
+        14,
+        20,
+        38
+      ],
       "player_perspectives": [
         2
       ],
@@ -75689,6 +79117,9 @@
       ],
       "name": "Hyrule Warriors",
       "parent_game": -1,
+      "platforms": [
+        41
+      ],
       "player_perspectives": [
         2
       ],
@@ -75763,6 +79194,9 @@
       ],
       "name": "Sonic Boom: Rise of Lyric",
       "parent_game": -1,
+      "platforms": [
+        41
+      ],
       "player_perspectives": [
         2
       ],
@@ -75839,6 +79273,13 @@
       ],
       "name": "Metal Gear Solid V: Ground Zeroes",
       "parent_game": 1985,
+      "platforms": [
+        6,
+        9,
+        12,
+        48,
+        49
+      ],
       "player_perspectives": [
         1,
         2
@@ -75932,6 +79373,13 @@
       "name": "Strider",
       "name_glogAppendReleaseYear": true,
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        48,
+        49
+      ],
       "player_perspectives": [
         4
       ],
@@ -76063,6 +79511,16 @@
       ],
       "name": "Ecco the Dolphin",
       "parent_game": -1,
+      "platforms": [
+        3,
+        5,
+        6,
+        12,
+        14,
+        29,
+        39,
+        78
+      ],
       "player_perspectives": [
         4
       ],
@@ -76155,6 +79613,12 @@
       ],
       "name": "Super Mario RPG: Legend of the Seven Stars",
       "parent_game": -1,
+      "platforms": [
+        5,
+        19,
+        41,
+        58
+      ],
       "player_perspectives": [
         3
       ],
@@ -76219,6 +79683,16 @@
       ],
       "name": "SimEarth: The Living Planet",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14,
+        15,
+        16,
+        77,
+        78,
+        118,
+        149
+      ],
       "player_perspectives": [
         3
       ],
@@ -76296,6 +79770,10 @@
       ],
       "name": "Q.U.B.E.",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14
+      ],
       "player_perspectives": [
         1,
         7
@@ -76384,6 +79862,10 @@
       ],
       "name": "Afro Samurai",
       "parent_game": -1,
+      "platforms": [
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -76499,6 +79981,12 @@
       ],
       "name": "Batman: Arkham Knight",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         2
       ],
@@ -76610,6 +80098,16 @@
       ],
       "name": "The Banner Saga",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        34,
+        39,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -76715,6 +80213,20 @@
       ],
       "name": "Golden Axe",
       "parent_game": -1,
+      "platforms": [
+        5,
+        9,
+        12,
+        13,
+        15,
+        16,
+        25,
+        26,
+        52,
+        63,
+        86,
+        123
+      ],
       "player_perspectives": [
         2,
         4
@@ -76792,6 +80304,15 @@
       ],
       "name": "Lyne",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        34,
+        39,
+        74,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -76842,6 +80363,11 @@
       ],
       "name": "Particulars",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -76964,6 +80490,11 @@
       ],
       "name": "Deus Ex: The Fall",
       "parent_game": -1,
+      "platforms": [
+        6,
+        34,
+        39
+      ],
       "player_perspectives": [
         1
       ],
@@ -77053,6 +80584,13 @@
       "name": "The Witness",
       "name_glogAppendReleaseYear": true,
       "parent_game": -1,
+      "platforms": [
+        6,
+        14,
+        39,
+        48,
+        49
+      ],
       "player_perspectives": [
         1
       ],
@@ -77175,6 +80713,12 @@
       ],
       "name": "Assassin's Creed Unity",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49,
+        170
+      ],
       "player_perspectives": [
         2
       ],
@@ -77253,6 +80797,13 @@
       ],
       "name": "Kentucky Route Zero",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        34,
+        39
+      ],
       "player_perspectives": [
         4
       ],
@@ -77360,6 +80911,11 @@
       ],
       "name": "Hell Yeah! Wrath of the Dead Rabbit",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         4
       ],
@@ -77497,6 +81053,15 @@
       ],
       "name": "Costume Quest",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        9,
+        12,
+        14,
+        34,
+        39
+      ],
       "player_perspectives": [
         3
       ],
@@ -77608,6 +81173,9 @@
       ],
       "name": "Too Human",
       "parent_game": -1,
+      "platforms": [
+        12
+      ],
       "player_perspectives": [
         1,
         2
@@ -77685,6 +81253,11 @@
       ],
       "name": "Age of Wonders III",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         2,
         3
@@ -77770,6 +81343,18 @@
       ],
       "name": "SteamWorld Dig",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        37,
+        41,
+        46,
+        48,
+        49,
+        130,
+        170
+      ],
       "player_perspectives": [
         4
       ],
@@ -77853,6 +81438,10 @@
       ],
       "name": "Evil Dead: A Fistful of Boomstick",
       "parent_game": -1,
+      "platforms": [
+        8,
+        11
+      ],
       "player_perspectives": [
         2
       ],
@@ -77911,6 +81500,10 @@
       ],
       "name": "Gun Metal",
       "parent_game": -1,
+      "platforms": [
+        6,
+        11
+      ],
       "player_perspectives": [
         2
       ],
@@ -78003,6 +81596,16 @@
       ],
       "name": "The Swapper",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        9,
+        14,
+        41,
+        46,
+        48,
+        49
+      ],
       "player_perspectives": [
         4
       ],
@@ -78078,6 +81681,14 @@
       ],
       "name": "Foul Play",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        12,
+        14,
+        46,
+        48
+      ],
       "player_perspectives": [
         4
       ],
@@ -78176,6 +81787,10 @@
       ],
       "name": "Shadows of the Damned",
       "parent_game": -1,
+      "platforms": [
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -78258,6 +81873,14 @@
       ],
       "name": "Broforce",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -78331,6 +81954,9 @@
       ],
       "name": "Viewtiful Joe: Double Trouble!",
       "parent_game": -1,
+      "platforms": [
+        20
+      ],
       "player_perspectives": [
         4
       ],
@@ -78406,6 +82032,11 @@
       ],
       "name": "Psi-Ops: The Mindgate Conspiracy",
       "parent_game": -1,
+      "platforms": [
+        6,
+        8,
+        11
+      ],
       "player_perspectives": [
         2
       ],
@@ -78469,6 +82100,15 @@
       ],
       "name": "Kingdom Rush",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        34,
+        39,
+        49,
+        130
+      ],
       "player_perspectives": [
         3
       ],
@@ -78573,6 +82213,17 @@
       ],
       "name": "Borderlands: The Pre-Sequel",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        9,
+        12,
+        14,
+        34,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         1
       ],
@@ -78652,6 +82303,9 @@
       ],
       "name": "The Last of Us Remastered",
       "parent_game": 1009,
+      "platforms": [
+        48
+      ],
       "player_perspectives": [
         2
       ],
@@ -78766,6 +82420,11 @@
       ],
       "name": "Sid Meier's Civilization: Beyond Earth",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         3
       ],
@@ -78841,6 +82500,13 @@
       ],
       "name": "Not a Hero",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        48,
+        49
+      ],
       "player_perspectives": [
         4
       ],
@@ -78997,6 +82663,13 @@
       "name": "Shadow Warrior",
       "name_glogAppendReleaseYear": true,
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        48,
+        49
+      ],
       "player_perspectives": [
         1
       ],
@@ -79061,6 +82734,11 @@
       ],
       "name": "The Elder Scrolls V: Skyrim - Hearthfire",
       "parent_game": 472,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         1,
         2
@@ -79115,6 +82793,11 @@
       ],
       "name": "The Elder Scrolls V: Skyrim - Dragonborn",
       "parent_game": 472,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         1,
         2
@@ -79167,6 +82850,9 @@
       ],
       "name": "PaRappa the Rapper",
       "parent_game": -1,
+      "platforms": [
+        7
+      ],
       "player_perspectives": [
         2
       ],
@@ -79229,6 +82915,9 @@
       ],
       "name": "Flicky",
       "parent_game": -1,
+      "platforms": [
+        52
+      ],
       "player_perspectives": [
         4
       ],
@@ -79299,6 +82988,9 @@
       ],
       "name": "Valdis Story: Abyssal City",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [
         4
       ],
@@ -79351,6 +83043,11 @@
       ],
       "name": "Stranglehold",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -79442,6 +83139,13 @@
       ],
       "name": "Mercenary Kings",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14,
+        46,
+        48,
+        49
+      ],
       "player_perspectives": [
         4
       ],
@@ -79526,6 +83230,12 @@
       ],
       "name": "Insanely Twisted Shadow Planet",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        12,
+        14
+      ],
       "player_perspectives": [
         4
       ],
@@ -79593,6 +83303,11 @@
       ],
       "name": "Tron 2.0",
       "parent_game": -1,
+      "platforms": [
+        6,
+        11,
+        14
+      ],
       "player_perspectives": [
         1
       ],
@@ -79672,6 +83387,10 @@
       ],
       "name": "E.Y.E: Divine Cybermancy",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6
+      ],
       "player_perspectives": [
         1
       ],
@@ -79768,6 +83487,13 @@
       ],
       "name": "Trine",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        9,
+        14,
+        41
+      ],
       "player_perspectives": [
         4
       ],
@@ -79832,6 +83558,15 @@
       ],
       "name": "Trine 2",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        9,
+        12,
+        14,
+        34,
+        41
+      ],
       "player_perspectives": [
         4
       ],
@@ -79935,6 +83670,9 @@
       ],
       "name": "Time Gentlemen, Please!",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [
         4
       ],
@@ -79999,6 +83737,13 @@
       ],
       "name": "Red Faction",
       "parent_game": -1,
+      "platforms": [
+        6,
+        8,
+        9,
+        14,
+        48
+      ],
       "player_perspectives": [
         1
       ],
@@ -80065,6 +83810,10 @@
       ],
       "name": "1000 Amps",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14
+      ],
       "player_perspectives": [
         4
       ],
@@ -80126,6 +83875,9 @@
       ],
       "name": "Boktai: The Sun Is in Your Hand",
       "parent_game": -1,
+      "platforms": [
+        24
+      ],
       "player_perspectives": [
         3
       ],
@@ -80238,6 +83990,11 @@
       ],
       "name": "Dwarf Fortress",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         3,
         5
@@ -80322,6 +84079,14 @@
       ],
       "name": "Solar 2",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        12,
+        14,
+        34,
+        39
+      ],
       "player_perspectives": [
         3
       ],
@@ -80376,6 +84141,9 @@
       "keywords": [],
       "name": "CIMA: The Enemy",
       "parent_game": -1,
+      "platforms": [
+        24
+      ],
       "player_perspectives": [
         3
       ],
@@ -80467,6 +84235,14 @@
       ],
       "name": "Contra III: The Alien Wars",
       "parent_game": -1,
+      "platforms": [
+        5,
+        19,
+        41,
+        52,
+        58,
+        137
+      ],
       "player_perspectives": [
         2,
         3,
@@ -80591,6 +84367,17 @@
       ],
       "name": "Gunstar Heroes",
       "parent_game": -1,
+      "platforms": [
+        3,
+        5,
+        6,
+        9,
+        12,
+        14,
+        29,
+        34,
+        39
+      ],
       "player_perspectives": [
         4
       ],
@@ -80678,6 +84465,11 @@
       ],
       "name": "Mario vs. Donkey Kong",
       "parent_game": -1,
+      "platforms": [
+        24,
+        37,
+        41
+      ],
       "player_perspectives": [
         4
       ],
@@ -80759,6 +84551,10 @@
       ],
       "name": "Mario vs. Donkey Kong 2: March of the Minis",
       "parent_game": -1,
+      "platforms": [
+        20,
+        41
+      ],
       "player_perspectives": [
         2,
         4
@@ -80857,6 +84653,9 @@
       ],
       "name": "Radiant Historia",
       "parent_game": -1,
+      "platforms": [
+        20
+      ],
       "player_perspectives": [
         3,
         4
@@ -80914,6 +84713,12 @@
       ],
       "name": "R-Type III: The Third Lightning",
       "parent_game": -1,
+      "platforms": [
+        5,
+        19,
+        24,
+        58
+      ],
       "player_perspectives": [
         2,
         4
@@ -81021,6 +84826,14 @@
       ],
       "name": "River City Ransom",
       "parent_game": 191641,
+      "platforms": [
+        5,
+        18,
+        37,
+        41,
+        49,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -81094,6 +84907,12 @@
       ],
       "name": "Rock n' Roll Racing",
       "parent_game": -1,
+      "platforms": [
+        6,
+        19,
+        24,
+        29
+      ],
       "player_perspectives": [
         2,
         3
@@ -81150,6 +84969,10 @@
       ],
       "name": "Scurge: Hive",
       "parent_game": -1,
+      "platforms": [
+        20,
+        24
+      ],
       "player_perspectives": [
         2,
         3
@@ -81250,6 +85073,9 @@
       ],
       "name": "Sword of Mana",
       "parent_game": 407,
+      "platforms": [
+        24
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -81336,6 +85162,11 @@
       ],
       "name": "Wheelman",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -81455,6 +85286,17 @@
       ],
       "name": "Tales from the Borderlands",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        14,
+        34,
+        39,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         2
       ],
@@ -81532,6 +85374,14 @@
       ],
       "name": "Rise & Shine",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -81598,6 +85448,9 @@
       ],
       "name": "Warlock II: The Exiled",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -81681,6 +85534,11 @@
       ],
       "name": "Sonic the Hedgehog 3",
       "parent_game": -1,
+      "platforms": [
+        5,
+        12,
+        29
+      ],
       "player_perspectives": [
         4
       ],
@@ -81834,6 +85692,9 @@
       ],
       "name": "Halo 5: Guardians",
       "parent_game": -1,
+      "platforms": [
+        49
+      ],
       "player_perspectives": [
         1,
         2
@@ -81960,6 +85821,15 @@
       ],
       "name": "LEGO Batman 2: DC Super Heroes",
       "parent_game": -1,
+      "platforms": [
+        5,
+        6,
+        9,
+        12,
+        14,
+        37,
+        41
+      ],
       "player_perspectives": [
         2
       ],
@@ -82084,6 +85954,13 @@
       ],
       "name": "Organ Trail: Director's Cut",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        34,
+        39
+      ],
       "player_perspectives": [
         4
       ],
@@ -82221,6 +86098,11 @@
       ],
       "name": "Binary Domain",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -82350,6 +86232,11 @@
       "name": "Bionic Commando",
       "name_glogAppendReleaseYear": true,
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -82433,6 +86320,10 @@
       ],
       "name": "Bodycount",
       "parent_game": -1,
+      "platforms": [
+        9,
+        12
+      ],
       "player_perspectives": [
         1
       ],
@@ -82583,6 +86474,11 @@
       "name": "Dante's Inferno",
       "name_glogAppendReleaseYear": true,
       "parent_game": -1,
+      "platforms": [
+        9,
+        12,
+        38
+      ],
       "player_perspectives": [
         2
       ],
@@ -82676,6 +86572,11 @@
       ],
       "name": "Dynasty Warriors: Gundam",
       "parent_game": -1,
+      "platforms": [
+        8,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -82782,6 +86683,10 @@
       ],
       "name": "Eternal Sonata",
       "parent_game": -1,
+      "platforms": [
+        9,
+        12
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -82849,6 +86754,10 @@
       ],
       "name": "Fairytale Fights",
       "parent_game": -1,
+      "platforms": [
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -82911,6 +86820,10 @@
       ],
       "name": "Fracture",
       "parent_game": -1,
+      "platforms": [
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -82964,6 +86877,10 @@
       ],
       "name": "Golden Axe: Beast Rider",
       "parent_game": -1,
+      "platforms": [
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -83073,6 +86990,11 @@
       ],
       "name": "Kane & Lynch: Dead Men",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -83146,6 +87068,12 @@
       ],
       "name": "Factorio",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        130
+      ],
       "player_perspectives": [
         3
       ],
@@ -83222,6 +87150,10 @@
       ],
       "name": "The Last Remnant",
       "parent_game": -1,
+      "platforms": [
+        6,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -83318,6 +87250,11 @@
       ],
       "name": "Legendary",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         1
       ],
@@ -83391,6 +87328,10 @@
       ],
       "name": "Majin and the Forsaken Kingdom",
       "parent_game": -1,
+      "platforms": [
+        9,
+        12
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -83462,6 +87403,10 @@
       ],
       "name": "Ilomilo",
       "parent_game": -1,
+      "platforms": [
+        6,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -83532,6 +87477,10 @@
       ],
       "name": "Ninja Blade",
       "parent_game": -1,
+      "platforms": [
+        6,
+        12
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -83596,6 +87545,10 @@
       ],
       "name": "Quantum Theory",
       "parent_game": -1,
+      "platforms": [
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -83665,6 +87618,9 @@
       ],
       "name": "Ico",
       "parent_game": -1,
+      "platforms": [
+        8
+      ],
       "player_perspectives": [
         2
       ],
@@ -83744,6 +87700,15 @@
       ],
       "name": "SuperHot",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        48,
+        49,
+        130,
+        170
+      ],
       "player_perspectives": [
         1
       ],
@@ -83837,6 +87802,11 @@
       ],
       "name": "A Story About My Uncle",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         1
       ],
@@ -83932,6 +87902,11 @@
       ],
       "name": "Tron: Evolution",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -83997,6 +87972,10 @@
       ],
       "name": "Vampire Rain",
       "parent_game": -1,
+      "platforms": [
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -84092,6 +88071,11 @@
       ],
       "name": "Viking: Battle for Asgard",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -84206,6 +88190,11 @@
       ],
       "name": "Wanted: Weapons of Fate",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -84265,6 +88254,11 @@
       ],
       "name": "Watchmen: The End Is Nigh",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -84321,6 +88315,9 @@
       ],
       "name": "3D Dot Game Heroes",
       "parent_game": -1,
+      "platforms": [
+        9
+      ],
       "player_perspectives": [
         2,
         3
@@ -84413,6 +88410,9 @@
       ],
       "name": "Heavenly Sword",
       "parent_game": -1,
+      "platforms": [
+        9
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -84518,6 +88518,16 @@
       ],
       "name": "Rise of the Tomb Raider",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        12,
+        14,
+        48,
+        49,
+        165,
+        170
+      ],
       "player_perspectives": [
         1,
         2,
@@ -84631,6 +88641,15 @@
       ],
       "name": "Valiant Hearts: The Great War",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        39,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -84746,6 +88765,9 @@
       ],
       "name": "Uncharted 4: A Thief's End",
       "parent_game": -1,
+      "platforms": [
+        48
+      ],
       "player_perspectives": [
         2
       ],
@@ -84824,6 +88846,10 @@
       ],
       "name": "Crackdown 3",
       "parent_game": -1,
+      "platforms": [
+        6,
+        49
+      ],
       "player_perspectives": [
         2
       ],
@@ -84891,6 +88917,9 @@
       ],
       "name": "Captain Toad: Treasure Tracker",
       "parent_game": -1,
+      "platforms": [
+        41
+      ],
       "player_perspectives": [
         2
       ],
@@ -84967,6 +88996,9 @@
       ],
       "name": "Mario Party 10",
       "parent_game": -1,
+      "platforms": [
+        41
+      ],
       "player_perspectives": [
         2
       ],
@@ -85073,6 +89105,14 @@
       "name": "Inside",
       "name_glogAppendReleaseYear": true,
       "parent_game": -1,
+      "platforms": [
+        6,
+        14,
+        39,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -85219,6 +89259,10 @@
       ],
       "name": "The Legend of Zelda: Breath of the Wild",
       "parent_game": -1,
+      "platforms": [
+        41,
+        130
+      ],
       "player_perspectives": [
         2
       ],
@@ -85453,6 +89497,11 @@
       ],
       "name": "Halo: The Master Chief Collection",
       "parent_game": -1,
+      "platforms": [
+        6,
+        49,
+        169
+      ],
       "player_perspectives": [
         1,
         2
@@ -85533,6 +89582,11 @@
       ],
       "name": "Mass Effect: Andromeda",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49
+      ],
       "player_perspectives": [
         2
       ],
@@ -85657,6 +89711,16 @@
       ],
       "name": "The Talos Principle",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        34,
+        39,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         1,
         2
@@ -85747,6 +89811,12 @@
       ],
       "name": "Papo & Yo",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        9,
+        14
+      ],
       "player_perspectives": [
         2
       ],
@@ -85824,6 +89894,14 @@
       ],
       "name": "Hoard",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        9,
+        14,
+        38,
+        46
+      ],
       "player_perspectives": [
         3
       ],
@@ -85906,6 +89984,13 @@
       ],
       "name": "Aquaria",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        34,
+        39
+      ],
       "player_perspectives": [
         4
       ],
@@ -85956,6 +90041,11 @@
       "keywords": [],
       "name": "Space Run: Fast and Safe Delivery",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         3
       ],
@@ -86061,6 +90151,14 @@
       ],
       "name": "Ristar",
       "parent_game": -1,
+      "platforms": [
+        3,
+        5,
+        6,
+        14,
+        29,
+        34
+      ],
       "player_perspectives": [
         4
       ],
@@ -86239,6 +90337,9 @@
       ],
       "name": "Valkyria Chronicles",
       "parent_game": -1,
+      "platforms": [
+        9
+      ],
       "player_perspectives": [
         2
       ],
@@ -86298,6 +90399,13 @@
       ],
       "name": "Shank",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        9,
+        12,
+        14
+      ],
       "player_perspectives": [
         4
       ],
@@ -86357,6 +90465,12 @@
       ],
       "name": "SimTower",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14,
+        32,
+        50
+      ],
       "player_perspectives": [
         4
       ],
@@ -86473,6 +90587,13 @@
       ],
       "name": "McPixel",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        34,
+        39
+      ],
       "player_perspectives": [
         4
       ],
@@ -86569,6 +90690,11 @@
       ],
       "name": "Assassin's Creed Rogue",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -86666,6 +90792,9 @@
       ],
       "name": "Space Rangers HD: A War Apart",
       "parent_game": 7593,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [
         3,
         5
@@ -86743,6 +90872,13 @@
       ],
       "name": "Hellblade: Senua's Sacrifice",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49,
+        130,
+        169
+      ],
       "player_perspectives": [
         2
       ],
@@ -86843,6 +90979,9 @@
       ],
       "name": "Until Dawn",
       "parent_game": -1,
+      "platforms": [
+        48
+      ],
       "player_perspectives": [
         2
       ],
@@ -86906,6 +91045,12 @@
       ],
       "name": "RiME",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         2
       ],
@@ -86985,6 +91130,12 @@
       ],
       "name": "Rush",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        41
+      ],
       "player_perspectives": [
         3
       ],
@@ -87057,6 +91208,18 @@
       ],
       "name": "Teslagrad",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        9,
+        14,
+        34,
+        41,
+        46,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -87134,6 +91297,11 @@
       ],
       "name": "Tiny Brains",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        48
+      ],
       "player_perspectives": [
         4
       ],
@@ -87188,6 +91356,10 @@
       ],
       "name": "Iron Brigade",
       "parent_game": -1,
+      "platforms": [
+        6,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -87274,6 +91446,10 @@
       ],
       "name": "Batman: Arkham Origins Blackgate",
       "parent_game": -1,
+      "platforms": [
+        37,
+        46
+      ],
       "player_perspectives": [
         2
       ],
@@ -87369,6 +91545,13 @@
       ],
       "name": "Saints Row: Gat Out of Hell",
       "parent_game": 1981,
+      "platforms": [
+        6,
+        9,
+        12,
+        48,
+        49
+      ],
       "player_perspectives": [
         2
       ],
@@ -87456,6 +91639,11 @@
       ],
       "name": "AI War: Fleet Command",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         3
       ],
@@ -87614,6 +91802,9 @@
       ],
       "name": "Septerra Core: Legacy of the Creator",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [
         3
       ],
@@ -87671,6 +91862,9 @@
       ],
       "name": "Sonic Boom: Shattered Crystal",
       "parent_game": -1,
+      "platforms": [
+        37
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -87767,6 +91961,9 @@
       ],
       "name": "Sonic Adventure 2: Battle",
       "parent_game": 7858,
+      "platforms": [
+        21
+      ],
       "player_perspectives": [
         2
       ],
@@ -87819,6 +92016,13 @@
       ],
       "name": "Savant: Ascent",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        34,
+        39
+      ],
       "player_perspectives": [
         4
       ],
@@ -87875,6 +92079,11 @@
       ],
       "name": "Defender's Quest: Valley of the Forgotten",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         3
       ],
@@ -87971,6 +92180,16 @@
       ],
       "name": "Ittle Dew",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        34,
+        39,
+        41,
+        72,
+        130
+      ],
       "player_perspectives": [
         3
       ],
@@ -88051,6 +92270,10 @@
       ],
       "name": "Marlow Briggs and the Mask of Death",
       "parent_game": -1,
+      "platforms": [
+        6,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -88229,6 +92452,14 @@
       ],
       "name": "Retro City Rampage",
       "parent_game": -1,
+      "platforms": [
+        5,
+        6,
+        9,
+        12,
+        37,
+        46
+      ],
       "player_perspectives": [
         3
       ],
@@ -88381,6 +92612,12 @@
       ],
       "name": "Jazzpunk",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        48
+      ],
       "player_perspectives": [
         1
       ],
@@ -88494,6 +92731,11 @@
       ],
       "name": "Lone Survivor",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         4
       ],
@@ -88549,6 +92791,9 @@
       ],
       "name": "Spelunky Classic",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [
         4
       ],
@@ -88627,6 +92872,12 @@
       ],
       "name": "Closure",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        9,
+        14
+      ],
       "player_perspectives": [
         4
       ],
@@ -88714,6 +92965,11 @@
       ],
       "name": "Just Cause 3",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49
+      ],
       "player_perspectives": [
         2
       ],
@@ -88776,6 +93032,9 @@
       ],
       "name": "Tetris",
       "parent_game": 130749,
+      "platforms": [
+        18
+      ],
       "player_perspectives": [
         4
       ],
@@ -88845,6 +93104,12 @@
       ],
       "name": "Cave Story+",
       "parent_game": 6189,
+      "platforms": [
+        3,
+        6,
+        14,
+        130
+      ],
       "player_perspectives": [
         4,
         5
@@ -88905,6 +93170,10 @@
       ],
       "name": "Prismata",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14
+      ],
       "player_perspectives": [
         3
       ],
@@ -88963,6 +93232,12 @@
       ],
       "name": "Assassin's Creed III: The Tyranny of King Washington",
       "parent_game": 1266,
+      "platforms": [
+        6,
+        9,
+        12,
+        41
+      ],
       "player_perspectives": [
         2
       ],
@@ -89037,6 +93312,13 @@
       ],
       "name": "Dark Souls II: Scholar of the First Sin",
       "parent_game": 2368,
+      "platforms": [
+        6,
+        9,
+        12,
+        48,
+        49
+      ],
       "player_perspectives": [
         2
       ],
@@ -89116,6 +93398,9 @@
       ],
       "name": "Grey Goo",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [
         3
       ],
@@ -89177,6 +93462,14 @@
       ],
       "name": "Trine 3: The Artifacts of Power",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         2
       ],
@@ -89238,6 +93531,13 @@
       ],
       "name": "Tacoma",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        48,
+        49
+      ],
       "player_perspectives": [
         1
       ],
@@ -89321,6 +93621,11 @@
       ],
       "name": "Magrunner: Dark Pulse",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         1
       ],
@@ -89424,6 +93729,13 @@
       ],
       "name": "Titan Quest",
       "parent_game": -1,
+      "platforms": [
+        6,
+        34,
+        39,
+        48,
+        49
+      ],
       "player_perspectives": [
         3
       ],
@@ -89476,6 +93788,15 @@
       ],
       "name": "Bejeweled",
       "parent_game": -1,
+      "platforms": [
+        6,
+        11,
+        14,
+        39,
+        73,
+        405,
+        417
+      ],
       "player_perspectives": [],
       "ports": [
         281616,
@@ -89571,6 +93892,9 @@
       ],
       "name": "Splosion Man",
       "parent_game": -1,
+      "platforms": [
+        12
+      ],
       "player_perspectives": [
         4
       ],
@@ -89650,6 +93974,13 @@
       ],
       "name": "Outland",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        9,
+        12,
+        14
+      ],
       "player_perspectives": [
         4
       ],
@@ -89717,6 +94048,12 @@
       ],
       "name": "Bardbarian",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14,
+        34,
+        39
+      ],
       "player_perspectives": [
         3
       ],
@@ -89780,6 +94117,11 @@
       ],
       "name": "Vessel",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        9
+      ],
       "player_perspectives": [
         4
       ],
@@ -89860,6 +94202,14 @@
       ],
       "name": "ToeJam & Earl",
       "parent_game": -1,
+      "platforms": [
+        3,
+        5,
+        6,
+        9,
+        14,
+        29
+      ],
       "player_perspectives": [
         3
       ],
@@ -89943,6 +94293,13 @@
       ],
       "name": "SpaceChem",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        34,
+        39
+      ],
       "player_perspectives": [
         3
       ],
@@ -90002,6 +94359,11 @@
       ],
       "name": "Blood Knights",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         3
       ],
@@ -90090,6 +94452,10 @@
       ],
       "name": "Cthulhu Saves the World",
       "parent_game": -1,
+      "platforms": [
+        6,
+        12
+      ],
       "player_perspectives": [
         3
       ],
@@ -90162,6 +94528,16 @@
       ],
       "name": "Shantae and the Pirate's Curse",
       "parent_game": -1,
+      "platforms": [
+        6,
+        37,
+        41,
+        48,
+        49,
+        130,
+        167,
+        170
+      ],
       "player_perspectives": [
         4
       ],
@@ -90250,6 +94626,18 @@
       ],
       "name": "The Bridge",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        9,
+        12,
+        14,
+        41,
+        46,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -90317,6 +94705,11 @@
       ],
       "name": "Lisa: The Painful",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         4
       ],
@@ -90387,6 +94780,13 @@
       ],
       "name": "Strike Suit Zero",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        48,
+        49
+      ],
       "player_perspectives": [
         2,
         7
@@ -90450,6 +94850,11 @@
       ],
       "name": "Shaq-Fu",
       "parent_game": -1,
+      "platforms": [
+        16,
+        19,
+        29
+      ],
       "player_perspectives": [
         4
       ],
@@ -90505,6 +94910,13 @@
       ],
       "name": "Uplink",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        34,
+        39
+      ],
       "player_perspectives": [
         5
       ],
@@ -90562,6 +94974,9 @@
       ],
       "name": "The Legend of Zelda: Majora's Mask 3D",
       "parent_game": 1030,
+      "platforms": [
+        37
+      ],
       "player_perspectives": [
         2,
         3
@@ -90648,6 +95063,14 @@
       ],
       "name": "Citizens of Earth",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        37,
+        41,
+        46,
+        48
+      ],
       "player_perspectives": [
         3
       ],
@@ -90701,6 +95124,9 @@
       ],
       "name": "C.O.P. The Recruit",
       "parent_game": -1,
+      "platforms": [
+        20
+      ],
       "player_perspectives": [
         2
       ],
@@ -90758,6 +95184,12 @@
       ],
       "name": "A.N.N.E.",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        41
+      ],
       "player_perspectives": [
         4
       ],
@@ -90841,6 +95273,16 @@
       ],
       "name": "Axiom Verge",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        41,
+        46,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -90897,6 +95339,17 @@
       ],
       "name": "Grim Fandango Remastered",
       "parent_game": 181,
+      "platforms": [
+        3,
+        6,
+        14,
+        34,
+        39,
+        46,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         3
       ],
@@ -90956,6 +95409,12 @@
       ],
       "name": "Element4l",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        46,
+        48
+      ],
       "player_perspectives": [
         4
       ],
@@ -91018,6 +95477,10 @@
       ],
       "name": "The Basement Collection",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14
+      ],
       "player_perspectives": [
         4
       ],
@@ -91104,6 +95567,13 @@
       ],
       "name": "Monaco: What's Yours Is Mine",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        12,
+        14,
+        130
+      ],
       "player_perspectives": [
         3
       ],
@@ -91164,6 +95634,11 @@
       ],
       "name": "Drox Operative",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         2
       ],
@@ -91248,6 +95723,16 @@
       ],
       "name": "Anomaly: Warzone Earth",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        9,
+        12,
+        14,
+        34,
+        39,
+        73
+      ],
       "player_perspectives": [
         3
       ],
@@ -91321,6 +95806,11 @@
       ],
       "name": "Grow Home",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        48
+      ],
       "player_perspectives": [
         2
       ],
@@ -91410,6 +95900,10 @@
       ],
       "name": "God Hand",
       "parent_game": -1,
+      "platforms": [
+        8,
+        9
+      ],
       "player_perspectives": [
         2
       ],
@@ -91466,6 +95960,9 @@
       ],
       "name": "Scribblenauts",
       "parent_game": -1,
+      "platforms": [
+        20
+      ],
       "player_perspectives": [
         4
       ],
@@ -91523,6 +96020,11 @@
       ],
       "name": "QWOP",
       "parent_game": -1,
+      "platforms": [
+        34,
+        55,
+        82
+      ],
       "player_perspectives": [
         4
       ],
@@ -91583,6 +96085,10 @@
       ],
       "name": "Starpoint Gemini 2",
       "parent_game": -1,
+      "platforms": [
+        6,
+        49
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -91637,6 +96143,12 @@
       ],
       "name": "Mitsurugi Kamui Hikae",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         2
       ],
@@ -91712,6 +96224,14 @@
       ],
       "name": "Guacamelee! Super Turbo Championship Edition",
       "parent_game": 19121,
+      "platforms": [
+        6,
+        12,
+        41,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -91836,6 +96356,18 @@
       ],
       "name": "Shadowrun: Dragonfall - Director's Cut",
       "parent_game": 3020,
+      "platforms": [
+        3,
+        6,
+        14,
+        34,
+        39,
+        48,
+        49,
+        130,
+        167,
+        169
+      ],
       "player_perspectives": [
         3
       ],
@@ -91891,6 +96423,15 @@
       "keywords": [],
       "name": "Super Time Force Ultra",
       "parent_game": 5336,
+      "platforms": [
+        3,
+        6,
+        12,
+        14,
+        46,
+        48,
+        49
+      ],
       "player_perspectives": [
         4
       ],
@@ -91967,6 +96508,12 @@
       ],
       "name": "Sunless Sea",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        39
+      ],
       "player_perspectives": [
         3
       ],
@@ -92044,6 +96591,11 @@
       ],
       "name": "Offspring Fling!",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         4
       ],
@@ -92130,6 +96682,12 @@
       ],
       "name": "Blocks That Matter",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        12,
+        14
+      ],
       "player_perspectives": [
         4
       ],
@@ -92253,6 +96811,10 @@
       ],
       "name": "The Legend of Heroes: Trails in the Sky",
       "parent_game": -1,
+      "platforms": [
+        6,
+        38
+      ],
       "player_perspectives": [
         2,
         3
@@ -92359,6 +96921,10 @@
       "name": "Conan",
       "name_glogAppendReleaseYear": true,
       "parent_game": -1,
+      "platforms": [
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -92415,6 +96981,13 @@
       ],
       "name": "Syder Arcade",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        34,
+        39
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -92481,6 +97054,14 @@
       ],
       "name": "Chroma Squad",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         3
       ],
@@ -92555,6 +97136,13 @@
       ],
       "name": "80 Days",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14,
+        34,
+        39,
+        130
+      ],
       "player_perspectives": [
         5
       ],
@@ -92625,6 +97213,12 @@
       ],
       "name": "Ibb & Obb",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        9,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -92688,6 +97282,9 @@
       ],
       "name": "Doc Louis's Punch-Out!!",
       "parent_game": 2194,
+      "platforms": [
+        5
+      ],
       "player_perspectives": [
         2
       ],
@@ -92783,6 +97380,11 @@
       ],
       "name": "Wolfenstein: The Old Blood",
       "parent_game": 2031,
+      "platforms": [
+        6,
+        48,
+        49
+      ],
       "player_perspectives": [
         1
       ],
@@ -92848,6 +97450,13 @@
       ],
       "name": "Shiftlings",
       "parent_game": -1,
+      "platforms": [
+        6,
+        41,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -92916,6 +97525,11 @@
       ],
       "name": "Tembo the Badass Elephant",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49
+      ],
       "player_perspectives": [
         4
       ],
@@ -92976,6 +97590,10 @@
       ],
       "name": "Deadly Premonition: Director's Cut",
       "parent_game": 1276,
+      "platforms": [
+        6,
+        9
+      ],
       "player_perspectives": [
         2
       ],
@@ -93074,6 +97692,9 @@
       ],
       "name": "Hotel Dusk: Room 215",
       "parent_game": -1,
+      "platforms": [
+        20
+      ],
       "player_perspectives": [
         1,
         3,
@@ -93136,6 +97757,17 @@
       ],
       "name": "Subnautica",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14,
+        48,
+        49,
+        130,
+        163,
+        167,
+        169,
+        385
+      ],
       "player_perspectives": [
         1,
         7
@@ -93208,6 +97840,9 @@
       ],
       "name": "Strike Suit Infinity",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [
         1,
         2
@@ -93320,6 +97955,9 @@
       ],
       "name": "The Typing of the Dead: Overkill",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [
         1
       ],
@@ -93398,6 +98036,10 @@
       ],
       "name": "Toy Soldiers",
       "parent_game": -1,
+      "platforms": [
+        6,
+        12
+      ],
       "player_perspectives": [
         3
       ],
@@ -93482,6 +98124,12 @@
       ],
       "name": "Strong Bad's Cool Game for Attractive People",
       "parent_game": -1,
+      "platforms": [
+        5,
+        6,
+        9,
+        14
+      ],
       "player_perspectives": [
         2
       ],
@@ -93533,6 +98181,12 @@
       "keywords": [],
       "name": "Strike Suit Zero: Director's Cut",
       "parent_game": 8507,
+      "platforms": [
+        6,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -93617,6 +98271,11 @@
       ],
       "name": "Sonic & Knuckles",
       "parent_game": 6797,
+      "platforms": [
+        5,
+        12,
+        29
+      ],
       "player_perspectives": [
         4
       ],
@@ -93721,6 +98380,13 @@
       ],
       "name": "Sonic 3D Blast",
       "parent_game": -1,
+      "platforms": [
+        3,
+        5,
+        6,
+        14,
+        29
+      ],
       "player_perspectives": [
         1,
         2
@@ -93790,6 +98456,14 @@
       ],
       "name": "So Many Me",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        48,
+        49,
+        72
+      ],
       "player_perspectives": [
         4
       ],
@@ -93968,6 +98642,13 @@
       ],
       "name": "Deus Ex: Mankind Divided",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        48,
+        49
+      ],
       "player_perspectives": [
         1,
         2
@@ -94040,6 +98721,13 @@
       ],
       "name": "SimAnt",
       "parent_game": -1,
+      "platforms": [
+        6,
+        13,
+        14,
+        16,
+        19
+      ],
       "player_perspectives": [
         3,
         4
@@ -94095,6 +98783,11 @@
       ],
       "name": "Deus Ex: Human Revolution - The Missing Link",
       "parent_game": 43,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         1,
         2
@@ -94165,6 +98858,9 @@
       ],
       "name": "Ben There, Dan That!",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [
         4
       ],
@@ -94274,6 +98970,13 @@
       ],
       "name": "Zero Escape: Nine Hours, Nine Persons, Nine Doors",
       "parent_game": -1,
+      "platforms": [
+        6,
+        20,
+        46,
+        48,
+        49
+      ],
       "player_perspectives": [
         1,
         5
@@ -94357,6 +99060,11 @@
       ],
       "name": "No Time to Explain",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -94529,6 +99237,9 @@
       ],
       "name": "Super Smash Bros. for Wii U",
       "parent_game": -1,
+      "platforms": [
+        41
+      ],
       "player_perspectives": [
         4
       ],
@@ -94595,6 +99306,12 @@
       ],
       "name": "Hexcells",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        39
+      ],
       "player_perspectives": [
         1
       ],
@@ -94686,6 +99403,9 @@
       ],
       "name": "Super Smash Bros. for Nintendo 3DS",
       "parent_game": -1,
+      "platforms": [
+        37
+      ],
       "player_perspectives": [
         4
       ],
@@ -94802,6 +99522,13 @@
       ],
       "name": "Shank 2",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        9,
+        12,
+        14
+      ],
       "player_perspectives": [
         4
       ],
@@ -94985,6 +99712,13 @@
       ],
       "name": "Fallout 4",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49,
+        167,
+        169
+      ],
       "player_perspectives": [
         1,
         2
@@ -95050,6 +99784,13 @@
       ],
       "name": "Return of the Obra Dinn",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         1
       ],
@@ -95110,6 +99851,12 @@
       ],
       "name": "Infinifactory",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        48
+      ],
       "player_perspectives": [
         1
       ],
@@ -95187,6 +99934,13 @@
       ],
       "name": "10000000",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        34,
+        39
+      ],
       "player_perspectives": [
         4
       ],
@@ -95247,6 +100001,9 @@
       ],
       "name": "Ring Runner: Flight of the Sages",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [
         4
       ],
@@ -95310,6 +100067,12 @@
       ],
       "name": "Dungeons 2",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        48
+      ],
       "player_perspectives": [
         3
       ],
@@ -95393,6 +100156,13 @@
       ],
       "name": "And Yet It Moves",
       "parent_game": -1,
+      "platforms": [
+        3,
+        5,
+        6,
+        14,
+        39
+      ],
       "player_perspectives": [
         4
       ],
@@ -95462,6 +100232,12 @@
       ],
       "name": "Before the Echo",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        12,
+        14
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -95527,6 +100303,14 @@
       ],
       "name": "Caster",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        37,
+        39,
+        72
+      ],
       "player_perspectives": [
         2
       ],
@@ -95619,6 +100403,15 @@
       ],
       "name": "Hyper Light Drifter",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        41,
+        46,
+        48,
+        49
+      ],
       "player_perspectives": [
         3
       ],
@@ -95686,6 +100479,10 @@
       ],
       "name": "Squishy the Suicidal Pig",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14
+      ],
       "player_perspectives": [
         4
       ],
@@ -95739,6 +100536,10 @@
       ],
       "name": "Out There Somewhere",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14
+      ],
       "player_perspectives": [
         4
       ],
@@ -95787,6 +100588,9 @@
       "keywords": [],
       "name": "Lunar Knights",
       "parent_game": -1,
+      "platforms": [
+        20
+      ],
       "player_perspectives": [
         3
       ],
@@ -95870,6 +100674,10 @@
       ],
       "name": "Phantasy Star Online Episode I & II",
       "parent_game": 21968,
+      "platforms": [
+        11,
+        21
+      ],
       "player_perspectives": [
         2
       ],
@@ -95960,6 +100768,12 @@
       ],
       "name": "PixelJunk Shooter",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        9,
+        14
+      ],
       "player_perspectives": [
         4
       ],
@@ -96030,6 +100844,9 @@
       ],
       "name": "Aarklash: Legacy",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [
         3
       ],
@@ -96077,6 +100894,9 @@
       ],
       "name": "Another Perspective",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [
         4
       ],
@@ -96121,6 +100941,14 @@
       ],
       "name": "Cogs",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        9,
+        14,
+        34,
+        39
+      ],
       "player_perspectives": [
         4
       ],
@@ -96171,6 +100999,11 @@
       "keywords": [],
       "name": "Batman: Arkham Origins - Cold, Cold Heart",
       "parent_game": 2003,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -96249,6 +101082,15 @@
       ],
       "name": "Yooka-Laylee",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        41,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         2
       ],
@@ -96304,6 +101146,11 @@
       "keywords": [],
       "name": "Analogue: A Hate Story",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         5
       ],
@@ -96360,6 +101207,12 @@
       ],
       "name": "Battle Group 2",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        130
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -96415,6 +101268,16 @@
       ],
       "name": "BioShock Infinite: Burial at Sea - Episode 1",
       "parent_game": 127036,
+      "platforms": [
+        3,
+        6,
+        9,
+        12,
+        14,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         1
       ],
@@ -96478,6 +101341,9 @@
       ],
       "name": "Chronology",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -96524,6 +101390,10 @@
       ],
       "name": "Clickr",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6
+      ],
       "player_perspectives": [
         4
       ],
@@ -96596,6 +101466,14 @@
       ],
       "name": "Home",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14,
+        39,
+        46,
+        48,
+        130
+      ],
       "player_perspectives": [
         4,
         5
@@ -96671,6 +101549,9 @@
       ],
       "name": "Heat Signature",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [
         3
       ],
@@ -96739,6 +101620,11 @@
       ],
       "name": "Toren",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14,
+        48
+      ],
       "player_perspectives": [
         2
       ],
@@ -96799,6 +101685,9 @@
       ],
       "name": "Moonbase Alpha",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [
         2
       ],
@@ -96872,6 +101761,10 @@
       ],
       "name": "Hamilton's Great Adventure",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -96923,6 +101816,11 @@
       ],
       "name": "Freaking Meatbags",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         3
       ],
@@ -96970,6 +101868,9 @@
       "keywords": [],
       "name": "Legends of Persia",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [
         3
       ],
@@ -97024,6 +101925,13 @@
       ],
       "name": "Kairo",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        34,
+        39
+      ],
       "player_perspectives": [
         1,
         7
@@ -97076,6 +101984,10 @@
       ],
       "name": "Lexica",
       "parent_game": -1,
+      "platforms": [
+        6,
+        39
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -97134,6 +102046,9 @@
       ],
       "name": "Picross DS",
       "parent_game": -1,
+      "platforms": [
+        20
+      ],
       "player_perspectives": [
         5
       ],
@@ -97203,6 +102118,10 @@
       ],
       "name": "Picross 3D",
       "parent_game": -1,
+      "platforms": [
+        20,
+        41
+      ],
       "player_perspectives": [
         5
       ],
@@ -97248,6 +102167,9 @@
       "keywords": [],
       "name": "Onikira: Demon Killer",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -97298,6 +102220,10 @@
       ],
       "name": "Puzzle Bots",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6
+      ],
       "player_perspectives": [
         4
       ],
@@ -97347,6 +102273,10 @@
       ],
       "name": "Qbeh-1: The Atlas Cube",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14
+      ],
       "player_perspectives": [
         1,
         7
@@ -97419,6 +102349,15 @@
       ],
       "name": "Bloodstained: Ritual of the Night",
       "parent_game": -1,
+      "platforms": [
+        6,
+        39,
+        41,
+        48,
+        49,
+        130,
+        170
+      ],
       "player_perspectives": [
         4
       ],
@@ -97485,6 +102424,15 @@
       ],
       "name": "Swords & Soldiers",
       "parent_game": -1,
+      "platforms": [
+        3,
+        5,
+        6,
+        9,
+        14,
+        34,
+        39
+      ],
       "player_perspectives": [
         4
       ],
@@ -97562,6 +102510,12 @@
       ],
       "name": "Detective Grimoire: Secret of the Swamp",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        34
+      ],
       "player_perspectives": [
         1,
         4
@@ -97647,6 +102601,15 @@
       ],
       "name": "Sine Mora",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        34,
+        39,
+        46,
+        72
+      ],
       "player_perspectives": [
         4
       ],
@@ -97695,6 +102658,13 @@
       "keywords": [],
       "name": "Sleeping Dogs: Nightmare in North Point",
       "parent_game": 1267,
+      "platforms": [
+        6,
+        9,
+        12,
+        48,
+        49
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -97741,6 +102711,12 @@
       "keywords": [],
       "name": "Sleeping Dogs: Year of the Snake",
       "parent_game": 1267,
+      "platforms": [
+        6,
+        9,
+        12,
+        48
+      ],
       "player_perspectives": [
         2
       ],
@@ -97849,6 +102825,15 @@
       ],
       "name": "Stealth Bastard Deluxe",
       "parent_game": 10923,
+      "platforms": [
+        3,
+        6,
+        9,
+        14,
+        34,
+        39,
+        46
+      ],
       "player_perspectives": [
         4
       ],
@@ -97926,6 +102911,9 @@
       ],
       "name": "Uncharted: The Nathan Drake Collection",
       "parent_game": -1,
+      "platforms": [
+        48
+      ],
       "player_perspectives": [
         2
       ],
@@ -97987,6 +102975,12 @@
       ],
       "name": "The 39 Steps",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        39
+      ],
       "player_perspectives": [
         1,
         5,
@@ -98056,6 +103050,11 @@
       ],
       "name": "Hexcells Plus",
       "parent_game": 9603,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         1
       ],
@@ -98119,6 +103118,12 @@
       ],
       "name": "Hexcells Infinite",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        39
+      ],
       "player_perspectives": [
         1
       ],
@@ -98191,6 +103196,17 @@
       ],
       "name": "LEGO Marvel's Avengers",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        14,
+        37,
+        41,
+        46,
+        48,
+        49
+      ],
       "player_perspectives": [
         2
       ],
@@ -98283,6 +103299,16 @@
       ],
       "name": "Anodyne",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        34,
+        39,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         3
       ],
@@ -98421,6 +103447,11 @@
       ],
       "name": "Dishonored 2",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49
+      ],
       "player_perspectives": [
         1
       ],
@@ -98485,6 +103516,10 @@
       ],
       "name": "ReCore",
       "parent_game": -1,
+      "platforms": [
+        6,
+        49
+      ],
       "player_perspectives": [
         2
       ],
@@ -98568,6 +103603,10 @@
       ],
       "name": "Horizon Zero Dawn",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48
+      ],
       "player_perspectives": [
         2
       ],
@@ -98658,6 +103697,14 @@
       "name": "Hitman",
       "name_glogAppendReleaseYear": true,
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        48,
+        49,
+        170
+      ],
       "player_perspectives": [
         2
       ],
@@ -98747,6 +103794,12 @@
       ],
       "name": "South Park: The Fractured But Whole",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -98813,6 +103866,10 @@
       ],
       "name": "Final Fantasy VII Remake",
       "parent_game": 427,
+      "platforms": [
+        48,
+        167
+      ],
       "player_perspectives": [
         2
       ],
@@ -98873,6 +103930,13 @@
       ],
       "name": "Transformers: Devastation",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        48,
+        49
+      ],
       "player_perspectives": [
         2
       ],
@@ -98952,6 +104016,12 @@
       ],
       "name": "Ronin",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        48
+      ],
       "player_perspectives": [
         4
       ],
@@ -99042,6 +104112,10 @@
       ],
       "name": "Gears of War 4",
       "parent_game": -1,
+      "platforms": [
+        6,
+        49
+      ],
       "player_perspectives": [
         2
       ],
@@ -99115,6 +104189,9 @@
       ],
       "name": "The Legend of Zelda: Tri Force Heroes",
       "parent_game": -1,
+      "platforms": [
+        37
+      ],
       "player_perspectives": [
         3
       ],
@@ -99215,6 +104292,9 @@
       ],
       "name": "Star Fox Zero",
       "parent_game": -1,
+      "platforms": [
+        41
+      ],
       "player_perspectives": [
         1,
         2
@@ -99297,6 +104377,10 @@
       ],
       "name": "NieR: Automata",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48
+      ],
       "player_perspectives": [
         2,
         4
@@ -99388,6 +104472,9 @@
       ],
       "name": "Star Ocean",
       "parent_game": -1,
+      "platforms": [
+        58
+      ],
       "player_perspectives": [
         3
       ],
@@ -99494,6 +104581,11 @@
       ],
       "name": "Trials of Mana",
       "parent_game": -1,
+      "platforms": [
+        19,
+        58,
+        306
+      ],
       "player_perspectives": [
         3
       ],
@@ -99573,6 +104665,9 @@
       ],
       "name": "Contra ReBirth",
       "parent_game": -1,
+      "platforms": [
+        5
+      ],
       "player_perspectives": [
         4
       ],
@@ -99640,6 +104735,10 @@
       ],
       "name": "The Oregon Trail",
       "parent_game": -1,
+      "platforms": [
+        104,
+        109
+      ],
       "player_perspectives": [
         5
       ],
@@ -99769,6 +104868,12 @@
       ],
       "name": "Shadow Complex",
       "parent_game": -1,
+      "platforms": [
+        6,
+        12,
+        48,
+        49
+      ],
       "player_perspectives": [
         4
       ],
@@ -99841,6 +104946,13 @@
       ],
       "name": "Her Story",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        34,
+        39
+      ],
       "player_perspectives": [
         1
       ],
@@ -99937,6 +105049,12 @@
       ],
       "name": "Yakuza 0",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        48,
+        49
+      ],
       "player_perspectives": [
         2
       ],
@@ -100016,6 +105134,19 @@
       ],
       "name": "The Jackbox Party Pack",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        9,
+        12,
+        14,
+        34,
+        39,
+        48,
+        49,
+        130,
+        132
+      ],
       "player_perspectives": [
         5
       ],
@@ -100081,6 +105212,14 @@
       ],
       "name": "AER: Memories of Old",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         2
       ],
@@ -100154,6 +105293,11 @@
       ],
       "name": "The Surge",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49
+      ],
       "player_perspectives": [
         2
       ],
@@ -100221,6 +105365,14 @@
       ],
       "name": "Ittle Dew 2",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         3
       ],
@@ -100295,6 +105447,12 @@
       "name": "The Room",
       "name_glogAppendReleaseYear": true,
       "parent_game": -1,
+      "platforms": [
+        6,
+        34,
+        39,
+        130
+      ],
       "player_perspectives": [
         1
       ],
@@ -100356,6 +105514,13 @@
       ],
       "name": "Epistory: Typing Chronicles",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        130,
+        170
+      ],
       "player_perspectives": [
         3
       ],
@@ -100422,6 +105587,11 @@
       ],
       "name": "Hacknet",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         5
       ],
@@ -100508,6 +105678,12 @@
       ],
       "name": "Rebel Galaxy",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14,
+        48,
+        49
+      ],
       "player_perspectives": [
         2
       ],
@@ -100578,6 +105754,14 @@
       ],
       "name": "Outer Wilds",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49,
+        130,
+        167,
+        169
+      ],
       "player_perspectives": [
         1
       ],
@@ -100666,6 +105850,12 @@
       ],
       "name": "Evoland 2",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14,
+        34,
+        39
+      ],
       "player_perspectives": [
         2,
         3,
@@ -100734,6 +105924,9 @@
       ],
       "name": "Universe Sandbox Legacy",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [
         4
       ],
@@ -100805,6 +105998,11 @@
       ],
       "name": "Phoenix Wright: Ace Attorney - Spirit of Justice",
       "parent_game": -1,
+      "platforms": [
+        34,
+        37,
+        39
+      ],
       "player_perspectives": [
         1,
         2,
@@ -100869,6 +106067,14 @@
       ],
       "name": "The Witcher 3: Wild Hunt - Hearts of Stone",
       "parent_game": 1942,
+      "platforms": [
+        6,
+        48,
+        49,
+        130,
+        167,
+        169
+      ],
       "player_perspectives": [
         2
       ],
@@ -100971,6 +106177,15 @@
       ],
       "name": "Undertale",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        46,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         3
       ],
@@ -101042,6 +106257,14 @@
       ],
       "name": "Lovers in a Dangerous Spacetime",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -101132,6 +106355,10 @@
       ],
       "name": "Recettear: An Item Shop's Tale",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6
+      ],
       "player_perspectives": [
         3,
         5
@@ -101189,6 +106416,9 @@
       ],
       "name": "Gravity Rush Remastered",
       "parent_game": 11701,
+      "platforms": [
+        48
+      ],
       "player_perspectives": [
         2
       ],
@@ -101244,6 +106474,13 @@
       "keywords": [],
       "name": "Danganronpa V3: Killing Harmony",
       "parent_game": -1,
+      "platforms": [
+        6,
+        39,
+        46,
+        48,
+        130
+      ],
       "player_perspectives": [
         1,
         2
@@ -101317,6 +106554,16 @@
       ],
       "name": "Job Simulator: The 2050 Archives",
       "parent_game": -1,
+      "platforms": [
+        161,
+        163,
+        165,
+        384,
+        385,
+        386,
+        390,
+        472
+      ],
       "player_perspectives": [
         1,
         7
@@ -101378,6 +106625,12 @@
       ],
       "name": "SimLife",
       "parent_game": -1,
+      "platforms": [
+        6,
+        13,
+        14,
+        16
+      ],
       "player_perspectives": [
         3
       ],
@@ -101445,6 +106698,11 @@
       ],
       "name": "Snapshot",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         4
       ],
@@ -101506,6 +106764,11 @@
       ],
       "name": "Stories: The Path of Destinies",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49
+      ],
       "player_perspectives": [
         3
       ],
@@ -101558,6 +106821,12 @@
       ],
       "name": "T2: The Arcade Game",
       "parent_game": -1,
+      "platforms": [
+        16,
+        19,
+        29,
+        52
+      ],
       "player_perspectives": [
         4
       ],
@@ -101621,6 +106890,14 @@
       ],
       "name": "The Witcher 3: Wild Hunt - Blood and Wine",
       "parent_game": 1942,
+      "platforms": [
+        6,
+        48,
+        49,
+        130,
+        167,
+        169
+      ],
       "player_perspectives": [
         2
       ],
@@ -101697,6 +106974,10 @@
       ],
       "name": "The Misadventures of P.B. Winterbottom",
       "parent_game": -1,
+      "platforms": [
+        6,
+        12
+      ],
       "player_perspectives": [
         4
       ],
@@ -101750,6 +107031,14 @@
       ],
       "name": "Refunct",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         1
       ],
@@ -101812,6 +107101,14 @@
       ],
       "name": "Indivisible",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -101883,6 +107180,12 @@
       ],
       "name": "Gateways",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        12,
+        14
+      ],
       "player_perspectives": [
         4
       ],
@@ -101935,6 +107238,11 @@
       ],
       "name": "Mass Effect 3: Citadel",
       "parent_game": 75,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         1
       ],
@@ -101988,6 +107296,11 @@
       ],
       "name": "Mass Effect: Bring Down the Sky",
       "parent_game": 73,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -102040,6 +107353,10 @@
       ],
       "name": "Mass Effect 2: Firewalker Pack",
       "parent_game": 74,
+      "platforms": [
+        6,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -102092,6 +107409,11 @@
       ],
       "name": "Mass Effect 2: Arrival",
       "parent_game": 74,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -102144,6 +107466,11 @@
       ],
       "name": "Mass Effect 2: Zaeed - The Price of Revenge",
       "parent_game": 74,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -102196,6 +107523,11 @@
       ],
       "name": "Mass Effect 2: Kasumi - Stolen Memory",
       "parent_game": 74,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -102240,6 +107572,9 @@
       ],
       "name": "Time Crisis 5",
       "parent_game": -1,
+      "platforms": [
+        52
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -102285,6 +107620,9 @@
       ],
       "name": "Lunar Legend",
       "parent_game": 5334,
+      "platforms": [
+        24
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -102333,6 +107671,10 @@
       ],
       "name": "Mass Effect 3: From Ashes",
       "parent_game": 75,
+      "platforms": [
+        6,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -102383,6 +107725,11 @@
       ],
       "name": "Mass Effect 3: Leviathan",
       "parent_game": 75,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -102434,6 +107781,11 @@
       ],
       "name": "Mass Effect 3: Omega",
       "parent_game": 75,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -102488,6 +107840,11 @@
       "keywords": [],
       "name": "Borderlands: The Pre-Sequel - Claptastic Voyage",
       "parent_game": 6032,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         1
       ],
@@ -102544,6 +107901,14 @@
       "keywords": [],
       "name": "Borderlands 2: Captain Scarlett and Her Pirate's Booty",
       "parent_game": 1011,
+      "platforms": [
+        3,
+        6,
+        9,
+        12,
+        14,
+        49
+      ],
       "player_perspectives": [
         1
       ],
@@ -102606,6 +107971,15 @@
       ],
       "name": "Borderlands 2: Mr. Torgue's Campaign of Carnage",
       "parent_game": 1011,
+      "platforms": [
+        3,
+        6,
+        9,
+        12,
+        14,
+        48,
+        49
+      ],
       "player_perspectives": [
         1
       ],
@@ -102666,6 +108040,14 @@
       "keywords": [],
       "name": "Borderlands 2: Sir Hammerlock's Big Game Hunt",
       "parent_game": 1011,
+      "platforms": [
+        3,
+        6,
+        9,
+        12,
+        14,
+        49
+      ],
       "player_perspectives": [
         1
       ],
@@ -102726,6 +108108,14 @@
       "keywords": [],
       "name": "Borderlands 2: Tiny Tina's Assault on Dragon Keep",
       "parent_game": 1011,
+      "platforms": [
+        3,
+        6,
+        9,
+        12,
+        14,
+        49
+      ],
       "player_perspectives": [
         1
       ],
@@ -102786,6 +108176,13 @@
       "keywords": [],
       "name": "Borderlands 2: T.K. Baha's Bloody Harvest",
       "parent_game": 1011,
+      "platforms": [
+        3,
+        6,
+        9,
+        12,
+        14
+      ],
       "player_perspectives": [
         1
       ],
@@ -102842,6 +108239,11 @@
       "keywords": [],
       "name": "Borderlands 2: The Horrible Hunger of the Ravenous Wattle Gobbler",
       "parent_game": 1011,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         1
       ],
@@ -102896,6 +108298,13 @@
       "keywords": [],
       "name": "Borderlands 2: How Marcus Saved Mercenary Day",
       "parent_game": 1011,
+      "platforms": [
+        3,
+        6,
+        9,
+        12,
+        14
+      ],
       "player_perspectives": [
         1
       ],
@@ -102951,6 +108360,13 @@
       "keywords": [],
       "name": "Borderlands 2: Mad Moxxi and the Wedding Day Massacre",
       "parent_game": 1011,
+      "platforms": [
+        3,
+        6,
+        9,
+        12,
+        14
+      ],
       "player_perspectives": [
         1
       ],
@@ -103006,6 +108422,13 @@
       "keywords": [],
       "name": "Borderlands 2: Sir Hammerlock vs. the Son of Crawmerax",
       "parent_game": 1011,
+      "platforms": [
+        3,
+        6,
+        9,
+        12,
+        14
+      ],
       "player_perspectives": [
         1
       ],
@@ -103070,6 +108493,13 @@
       ],
       "name": "Divinity: Original Sin - Enhanced Edition",
       "parent_game": 5082,
+      "platforms": [
+        3,
+        6,
+        14,
+        48,
+        49
+      ],
       "player_perspectives": [
         2,
         3
@@ -103127,6 +108557,12 @@
       "keywords": [],
       "name": "BioShock 2: Minerva's Den",
       "parent_game": 21,
+      "platforms": [
+        6,
+        9,
+        12,
+        14
+      ],
       "player_perspectives": [
         1
       ],
@@ -103182,6 +108618,15 @@
       ],
       "name": "Human Resource Machine",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        34,
+        39,
+        41,
+        130
+      ],
       "player_perspectives": [
         3
       ],
@@ -103253,6 +108698,13 @@
       ],
       "name": "Card City Nights",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        34,
+        39
+      ],
       "player_perspectives": [
         3,
         5
@@ -103307,6 +108759,13 @@
       "keywords": [],
       "name": "Dishonored: The Knife of Dunwall",
       "parent_game": 533,
+      "platforms": [
+        6,
+        9,
+        12,
+        48,
+        49
+      ],
       "player_perspectives": [
         1
       ],
@@ -103361,6 +108820,13 @@
       "keywords": [],
       "name": "Dishonored: The Brigmore Witches",
       "parent_game": 533,
+      "platforms": [
+        6,
+        9,
+        12,
+        48,
+        49
+      ],
       "player_perspectives": [
         1
       ],
@@ -103434,6 +108900,14 @@
       ],
       "name": "Ink",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -103498,6 +108972,16 @@
       ],
       "name": "Oxenfree",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        34,
+        39,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -103586,6 +109070,13 @@
       ],
       "name": "Hollow Knight",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        41,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -103646,6 +109137,10 @@
       ],
       "name": "Kalimba",
       "parent_game": -1,
+      "platforms": [
+        6,
+        49
+      ],
       "player_perspectives": [
         4
       ],
@@ -103715,6 +109210,10 @@
       ],
       "name": "The Deadly Tower of Monsters",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48
+      ],
       "player_perspectives": [
         3
       ],
@@ -103779,6 +109278,17 @@
       ],
       "name": "Batman: The Telltale Series",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        14,
+        34,
+        39,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         2
       ],
@@ -103848,6 +109358,10 @@
       ],
       "name": "Hob",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48
+      ],
       "player_perspectives": [
         3
       ],
@@ -103901,6 +109415,12 @@
       "keywords": [],
       "name": "Rise of the Tomb Raider: Baba Yaga - The Temple of the Witch",
       "parent_game": 7323,
+      "platforms": [
+        6,
+        12,
+        48,
+        49
+      ],
       "player_perspectives": [
         2
       ],
@@ -103957,6 +109477,13 @@
       ],
       "name": "Penny Arcade Adventures: On the Rain-Slick Precipice of Darkness - Episode Two",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        9,
+        12,
+        14
+      ],
       "player_perspectives": [
         3
       ],
@@ -104019,6 +109546,11 @@
       ],
       "name": "Spectraball",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -104073,6 +109605,13 @@
       ],
       "name": "Crayon Physics Deluxe",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        34,
+        39
+      ],
       "player_perspectives": [
         4
       ],
@@ -104150,6 +109689,13 @@
       ],
       "name": "Osmos",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        34,
+        39
+      ],
       "player_perspectives": [
         3
       ],
@@ -104204,6 +109750,13 @@
       ],
       "name": "Penny Arcade Adventures: On the Rain-Slick Precipice of Darkness - Episode One",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        9,
+        12,
+        14
+      ],
       "player_perspectives": [
         3
       ],
@@ -104263,6 +109816,13 @@
       "keywords": [],
       "name": "Penny Arcade's On the Rain-Slick Precipice of Darkness 3",
       "parent_game": -1,
+      "platforms": [
+        6,
+        12,
+        14,
+        34,
+        39
+      ],
       "player_perspectives": [
         3,
         4
@@ -104322,6 +109882,11 @@
       ],
       "name": "Penny Arcade's On the Rain-Slick Precipice of Darkness 4",
       "parent_game": -1,
+      "platforms": [
+        6,
+        12,
+        14
+      ],
       "player_perspectives": [
         3,
         4
@@ -104394,6 +109959,9 @@
       ],
       "name": "Children of Mana",
       "parent_game": -1,
+      "platforms": [
+        20
+      ],
       "player_perspectives": [
         2,
         3
@@ -104442,6 +110010,9 @@
       "keywords": [],
       "name": "Heroes of Mana",
       "parent_game": -1,
+      "platforms": [
+        20
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -104522,6 +110093,11 @@
       ],
       "name": "Dwarfs!?",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         3
       ],
@@ -104581,6 +110157,9 @@
       ],
       "name": "Saira",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -104629,6 +110208,11 @@
       ],
       "name": "Dynamite Jack",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -104711,6 +110295,19 @@
       ],
       "name": "SteamWorld Heist",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        37,
+        39,
+        41,
+        46,
+        48,
+        49,
+        130,
+        170
+      ],
       "player_perspectives": [
         4
       ],
@@ -104778,6 +110375,14 @@
       ],
       "name": "Crashlands",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14,
+        34,
+        39,
+        49,
+        130
+      ],
       "player_perspectives": [
         3
       ],
@@ -104845,6 +110450,15 @@
       ],
       "name": "VA-11 Hall-A: Cyberpunk Bartender Action",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        39,
+        46,
+        48,
+        130
+      ],
       "player_perspectives": [
         5
       ],
@@ -104911,6 +110525,11 @@
       ],
       "name": "Batman: Arkham Knight - A Matter of Family",
       "parent_game": 5503,
+      "platforms": [
+        6,
+        48,
+        49
+      ],
       "player_perspectives": [
         2
       ],
@@ -104971,6 +110590,11 @@
       ],
       "name": "Batman: Arkham Knight - Season of Infamy: Most Wanted Expansion",
       "parent_game": 5503,
+      "platforms": [
+        6,
+        48,
+        49
+      ],
       "player_perspectives": [
         2
       ],
@@ -105041,6 +110665,12 @@
       ],
       "name": "MirrorMoon EP",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        72
+      ],
       "player_perspectives": [
         1
       ],
@@ -105104,6 +110734,9 @@
       ],
       "name": "Peggle Extreme",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [
         4
       ],
@@ -105177,6 +110810,9 @@
       ],
       "name": "Metroid Dread",
       "parent_game": -1,
+      "platforms": [
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -105229,6 +110865,10 @@
       ],
       "name": "Aviary Attorney",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14
+      ],
       "player_perspectives": [
         4
       ],
@@ -105298,6 +110938,11 @@
       ],
       "name": "Pony Island",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         4,
         5
@@ -105345,6 +110990,12 @@
       ],
       "name": "Destination Sol",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        34
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -105396,6 +111047,11 @@
       ],
       "name": "The Talos Principle: Road to Gehenna",
       "parent_game": 7386,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         1,
         2,
@@ -105475,6 +111131,11 @@
       ],
       "name": "Bahamut Lagoon",
       "parent_game": -1,
+      "platforms": [
+        5,
+        41,
+        58
+      ],
       "player_perspectives": [
         3
       ],
@@ -105530,6 +111191,10 @@
       ],
       "name": "Fract Osc",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14
+      ],
       "player_perspectives": [
         1
       ],
@@ -105597,6 +111262,12 @@
       ],
       "name": "Headlander",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14,
+        48,
+        49
+      ],
       "player_perspectives": [
         4
       ],
@@ -105677,6 +111348,12 @@
       ],
       "name": "Massive Chalice",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        49
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -105732,6 +111409,12 @@
       ],
       "name": "Puzzle Agent",
       "parent_game": -1,
+      "platforms": [
+        5,
+        6,
+        9,
+        14
+      ],
       "player_perspectives": [
         4
       ],
@@ -105798,6 +111481,9 @@
       ],
       "name": "Tunnel Rats",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [
         1
       ],
@@ -105901,6 +111587,13 @@
       ],
       "name": "Sonic the Hedgehog: Spinball",
       "parent_game": -1,
+      "platforms": [
+        3,
+        5,
+        6,
+        14,
+        29
+      ],
       "player_perspectives": [
         4
       ],
@@ -105997,6 +111690,15 @@
       ],
       "name": "Greed Corp",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        9,
+        12,
+        14,
+        34,
+        39
+      ],
       "player_perspectives": [
         3
       ],
@@ -106064,6 +111766,11 @@
       ],
       "name": "Steel Storm: Burning Retribution",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -106133,6 +111840,10 @@
       ],
       "name": "Breath of Death VII",
       "parent_game": -1,
+      "platforms": [
+        6,
+        12
+      ],
       "player_perspectives": [
         3
       ],
@@ -106193,6 +111904,14 @@
       ],
       "name": "Toki Tori 2+",
       "parent_game": 2351,
+      "platforms": [
+        3,
+        6,
+        14,
+        41,
+        48,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -106260,6 +111979,14 @@
       ],
       "name": "Dragon's Dogma: Dark Arisen",
       "parent_game": 3968,
+      "platforms": [
+        6,
+        9,
+        12,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         2
       ],
@@ -106337,6 +112064,12 @@
       ],
       "name": "Paint it Back",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        39
+      ],
       "player_perspectives": [
         4
       ],
@@ -106395,6 +112128,10 @@
       ],
       "name": "Starseed Pilgrim",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14
+      ],
       "player_perspectives": [
         4
       ],
@@ -106485,6 +112222,11 @@
       ],
       "name": "Noitu Love 2: Devolution",
       "parent_game": -1,
+      "platforms": [
+        6,
+        37,
+        41
+      ],
       "player_perspectives": [
         4
       ],
@@ -106543,6 +112285,10 @@
       ],
       "name": "Drunken Robot Pornography",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6
+      ],
       "player_perspectives": [
         1
       ],
@@ -106620,6 +112366,15 @@
       ],
       "name": "Unmechanical",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        9,
+        12,
+        14,
+        34,
+        39
+      ],
       "player_perspectives": [
         4
       ],
@@ -106672,6 +112427,10 @@
       ],
       "name": "Retro/Grade",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -106734,6 +112493,11 @@
       ],
       "name": "Incredipede",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14,
+        34
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -106792,6 +112556,11 @@
       ],
       "name": "Hate Plus",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         5
       ],
@@ -106847,6 +112616,9 @@
       ],
       "name": "Ōkamiden",
       "parent_game": -1,
+      "platforms": [
+        20
+      ],
       "player_perspectives": [
         2
       ],
@@ -106898,6 +112670,11 @@
       ],
       "name": "Zigfrak",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -106983,6 +112760,12 @@
       ],
       "name": "Finding Teddy",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        39
+      ],
       "player_perspectives": [
         4
       ],
@@ -107044,6 +112827,9 @@
       ],
       "name": "Cloudbuilt",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [
         2
       ],
@@ -107122,6 +112908,15 @@
       ],
       "name": "Dex",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        46,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -107191,6 +112986,11 @@
       "name": "Epoch",
       "name_glogAppendReleaseYear": true,
       "parent_game": -1,
+      "platforms": [
+        6,
+        34,
+        39
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -107239,6 +113039,13 @@
       ],
       "name": "Shadow Blade: Reload",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        48,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -107312,6 +113119,13 @@
       ],
       "name": "Furi",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49,
+        130,
+        167
+      ],
       "player_perspectives": [
         2,
         3
@@ -107363,6 +113177,9 @@
       "keywords": [],
       "name": "GemCraft - Chasing Shadows",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -107410,6 +113227,9 @@
       ],
       "name": "The Desolate Hope",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [
         4
       ],
@@ -107501,6 +113321,11 @@
       ],
       "name": "Titanfall 2",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49
+      ],
       "player_perspectives": [
         1
       ],
@@ -107552,6 +113377,10 @@
       "keywords": [],
       "name": "Qora",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -107598,6 +113427,10 @@
       ],
       "name": "Zoo Rampage",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -107647,6 +113480,9 @@
       ],
       "name": "See No Evil",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -107687,6 +113523,11 @@
       "keywords": [],
       "name": "Great Permutator",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         3,
         5
@@ -107746,6 +113587,13 @@
       ],
       "name": "The Magic Circle",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        48,
+        49
+      ],
       "player_perspectives": [
         1
       ],
@@ -107805,6 +113653,11 @@
       ],
       "name": "Windward",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         3
       ],
@@ -107850,6 +113703,11 @@
       "keywords": [],
       "name": "Letter Quest: Grimm's Journey",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14,
+        34
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -107923,6 +113781,14 @@
       ],
       "name": "Stealth Inc 2: A Game of Clones",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        41,
+        46,
+        48,
+        49
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -107984,6 +113850,11 @@
       ],
       "name": "Fallout 4: Automatron",
       "parent_game": 9630,
+      "platforms": [
+        6,
+        48,
+        49
+      ],
       "player_perspectives": [
         1,
         2
@@ -108041,6 +113912,11 @@
       ],
       "name": "Fallout 4: Far Harbor",
       "parent_game": 9630,
+      "platforms": [
+        6,
+        48,
+        49
+      ],
       "player_perspectives": [
         1,
         2
@@ -108094,6 +113970,11 @@
       ],
       "name": "Bear Simulator",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         1
       ],
@@ -108152,6 +114033,9 @@
       ],
       "name": "Flower, Sun, and Rain",
       "parent_game": -1,
+      "platforms": [
+        8
+      ],
       "player_perspectives": [
         2
       ],
@@ -108223,6 +114107,14 @@
       ],
       "name": "Ultimate Chicken Horse",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -108304,6 +114196,14 @@
       ],
       "name": "Momodora: Reverie Under the Moonlight",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -108371,6 +114271,9 @@
       ],
       "name": "Lock's Quest",
       "parent_game": -1,
+      "platforms": [
+        20
+      ],
       "player_perspectives": [
         3
       ],
@@ -108429,6 +114332,13 @@
       ],
       "name": "The Turing Test",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49,
+        130,
+        170
+      ],
       "player_perspectives": [
         1
       ],
@@ -108485,6 +114395,13 @@
       ],
       "name": "Deadbolt",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        46,
+        48,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -108560,6 +114477,11 @@
       ],
       "name": "Overcooked!",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49
+      ],
       "player_perspectives": [
         3
       ],
@@ -108619,6 +114541,11 @@
       ],
       "name": "Batman: Arkham City - Harley Quinn's Revenge",
       "parent_game": 501,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -108682,6 +114609,14 @@
       ],
       "name": "Manual Samuel",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -108755,6 +114690,15 @@
       ],
       "name": "Oceanhorn: Monster of Uncharted Seas",
       "parent_game": 22117,
+      "platforms": [
+        6,
+        14,
+        34,
+        46,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         3
       ],
@@ -108813,6 +114757,12 @@
       ],
       "name": "Shadow Complex Remastered",
       "parent_game": 11328,
+      "platforms": [
+        6,
+        14,
+        48,
+        49
+      ],
       "player_perspectives": [
         4
       ],
@@ -108876,6 +114826,9 @@
       ],
       "name": "Fullmetal Alchemist: Dual Sympathy",
       "parent_game": -1,
+      "platforms": [
+        20
+      ],
       "player_perspectives": [
         4
       ],
@@ -108941,6 +114894,18 @@
       ],
       "name": "The Jackbox Party Pack 2",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        9,
+        14,
+        34,
+        39,
+        48,
+        49,
+        130,
+        132
+      ],
       "player_perspectives": [
         5
       ],
@@ -109021,6 +114986,17 @@
       ],
       "name": "The Jackbox Party Pack 3",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        34,
+        39,
+        48,
+        49,
+        130,
+        132
+      ],
       "player_perspectives": [
         5
       ],
@@ -109116,6 +115092,15 @@
       ],
       "name": "Sid Meier's Civilization VI",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        39,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         3
       ],
@@ -109182,6 +115167,17 @@
       ],
       "name": "CastleStorm",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12,
+        39,
+        41,
+        46,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -109254,6 +115250,15 @@
       "keywords": [],
       "name": "Borderlands 3",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14,
+        48,
+        49,
+        167,
+        169,
+        170
+      ],
       "player_perspectives": [
         1,
         2
@@ -109325,6 +115330,12 @@
       ],
       "name": "Snake Pass",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         2
       ],
@@ -109411,6 +115422,9 @@
       ],
       "name": "Sonic Rush",
       "parent_game": -1,
+      "platforms": [
+        20
+      ],
       "player_perspectives": [
         4
       ],
@@ -109472,6 +115486,11 @@
       ],
       "name": "Sam & Max: Save the World - Episode 4: Abe Lincoln Must Die!",
       "parent_game": 862,
+      "platforms": [
+        5,
+        6,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -109536,6 +115555,11 @@
       ],
       "name": "Agents of Mayhem",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49
+      ],
       "player_perspectives": [
         2
       ],
@@ -109598,6 +115622,11 @@
       ],
       "name": "Ori and the Blind Forest: Definitive Edition",
       "parent_game": 7344,
+      "platforms": [
+        6,
+        49,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -109656,6 +115685,13 @@
       ],
       "name": "The Elder Scrolls V: Skyrim - Special Edition",
       "parent_game": 472,
+      "platforms": [
+        6,
+        48,
+        49,
+        167,
+        169
+      ],
       "player_perspectives": [
         1,
         2
@@ -109731,6 +115767,13 @@
       ],
       "name": "Gwent: The Witcher Card Game",
       "parent_game": -1,
+      "platforms": [
+        6,
+        34,
+        39,
+        48,
+        49
+      ],
       "player_perspectives": [
         3
       ],
@@ -109878,6 +115921,11 @@
       "name": "Prey",
       "name_glogAppendReleaseYear": true,
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49
+      ],
       "player_perspectives": [
         1
       ],
@@ -109941,6 +115989,11 @@
       "keywords": [],
       "name": "Fallout 4: Vault-Tec Workshop",
       "parent_game": 9630,
+      "platforms": [
+        6,
+        48,
+        49
+      ],
       "player_perspectives": [
         1,
         2
@@ -109997,6 +116050,11 @@
       ],
       "name": "Fallout 4: Nuka World",
       "parent_game": 9630,
+      "platforms": [
+        6,
+        48,
+        49
+      ],
       "player_perspectives": [
         1,
         2
@@ -110077,6 +116135,10 @@
       ],
       "name": "Forza Horizon 3",
       "parent_game": -1,
+      "platforms": [
+        6,
+        49
+      ],
       "player_perspectives": [
         1,
         2
@@ -110162,6 +116224,10 @@
       "name": "God of War",
       "name_glogAppendReleaseYear": true,
       "parent_game": -1,
+      "platforms": [
+        6,
+        48
+      ],
       "player_perspectives": [
         2
       ],
@@ -110228,6 +116294,9 @@
       ],
       "name": "Marvel's Spider-Man",
       "parent_game": -1,
+      "platforms": [
+        48
+      ],
       "player_perspectives": [
         2
       ],
@@ -110282,6 +116351,10 @@
       ],
       "name": "Uncharted: Fortune Hunter",
       "parent_game": -1,
+      "platforms": [
+        34,
+        39
+      ],
       "player_perspectives": [
         3
       ],
@@ -110348,6 +116421,14 @@
       ],
       "name": "Mr. Shifty",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         3
       ],
@@ -110399,6 +116480,9 @@
       "keywords": [],
       "name": "Dungeon Explorer",
       "parent_game": -1,
+      "platforms": [
+        78
+      ],
       "player_perspectives": [
         3
       ],
@@ -110454,6 +116538,10 @@
       ],
       "name": "Eon Altar",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14
+      ],
       "player_perspectives": [
         3
       ],
@@ -110524,6 +116612,9 @@
       ],
       "name": "Crashmo",
       "parent_game": -1,
+      "platforms": [
+        37
+      ],
       "player_perspectives": [
         2,
         4
@@ -110584,6 +116675,9 @@
       ],
       "name": "Pokémon Picross",
       "parent_game": -1,
+      "platforms": [
+        37
+      ],
       "player_perspectives": [
         4
       ],
@@ -110645,6 +116739,15 @@
       ],
       "name": "Darksiders II: Deathinitive Edition",
       "parent_game": 1269,
+      "platforms": [
+        6,
+        48,
+        49,
+        130,
+        167,
+        169,
+        170
+      ],
       "player_perspectives": [
         2
       ],
@@ -110715,6 +116818,14 @@
       ],
       "name": "Katana Zero",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14,
+        34,
+        39,
+        49,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -110764,6 +116875,10 @@
       "keywords": [],
       "name": "Five: Guardians of David",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -110812,6 +116927,10 @@
       ],
       "name": "The Witcher: Enhanced Edition",
       "parent_game": 80,
+      "platforms": [
+        6,
+        14
+      ],
       "player_perspectives": [
         2
       ],
@@ -110900,6 +117019,9 @@
       ],
       "name": "Dead Rising 2: Case Zero",
       "parent_game": -1,
+      "platforms": [
+        12
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -110958,6 +117080,15 @@
       ],
       "name": "Pinstripe",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        39,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -111042,6 +117173,10 @@
       ],
       "name": "Star Fox Command",
       "parent_game": -1,
+      "platforms": [
+        20,
+        41
+      ],
       "player_perspectives": [
         1,
         2
@@ -111097,6 +117232,11 @@
       "keywords": [],
       "name": "Touch Detective",
       "parent_game": -1,
+      "platforms": [
+        20,
+        34,
+        130
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -111143,6 +117283,9 @@
       "keywords": [],
       "name": "Contact",
       "parent_game": -1,
+      "platforms": [
+        20
+      ],
       "player_perspectives": [
         3
       ],
@@ -111218,6 +117361,10 @@
       ],
       "name": "Yoshi's Island DS",
       "parent_game": -1,
+      "platforms": [
+        20,
+        41
+      ],
       "player_perspectives": [
         4
       ],
@@ -111270,6 +117417,10 @@
       ],
       "name": "Knights in the Nightmare",
       "parent_game": -1,
+      "platforms": [
+        20,
+        38
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -111336,6 +117487,12 @@
       ],
       "name": "The Witcher 2: Assassins of Kings - Enhanced Edition",
       "parent_game": 478,
+      "platforms": [
+        3,
+        6,
+        12,
+        14
+      ],
       "player_perspectives": [
         2
       ],
@@ -111396,6 +117553,13 @@
       ],
       "name": "Ōkami HD",
       "parent_game": 1271,
+      "platforms": [
+        6,
+        9,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         2
       ],
@@ -111467,6 +117631,10 @@
       ],
       "name": "Magnetic: Cage Closed",
       "parent_game": -1,
+      "platforms": [
+        6,
+        49
+      ],
       "player_perspectives": [
         1
       ],
@@ -111521,6 +117689,11 @@
       ],
       "name": "Dark Souls: Prepare to Die Edition",
       "parent_game": -1,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -111571,6 +117744,9 @@
       "keywords": [],
       "name": "Final Fantasy: Crystal Chronicles - My Life as a King",
       "parent_game": -1,
+      "platforms": [
+        5
+      ],
       "player_perspectives": [
         2
       ],
@@ -111615,6 +117791,9 @@
       ],
       "name": "Time Hollow",
       "parent_game": -1,
+      "platforms": [
+        20
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -111684,6 +117863,9 @@
       ],
       "name": "Mario vs. Donkey Kong: Mini-Land Mayhem!",
       "parent_game": -1,
+      "platforms": [
+        20
+      ],
       "player_perspectives": [
         4
       ],
@@ -111731,6 +117913,10 @@
       ],
       "name": "Black Sigil: Blade of the Exiled",
       "parent_game": -1,
+      "platforms": [
+        20,
+        24
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -111775,6 +117961,9 @@
       ],
       "name": "Avalon Code",
       "parent_game": -1,
+      "platforms": [
+        20
+      ],
       "player_perspectives": [
         3
       ],
@@ -111828,6 +118017,10 @@
       ],
       "name": "LostWinds: Winter of the Melodias",
       "parent_game": -1,
+      "platforms": [
+        5,
+        6
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -111881,6 +118074,9 @@
       ],
       "name": "Prince of Persia: The Fallen King",
       "parent_game": -1,
+      "platforms": [
+        20
+      ],
       "player_perspectives": [
         4
       ],
@@ -111943,6 +118139,9 @@
       ],
       "name": "Bangai-O Spirits",
       "parent_game": -1,
+      "platforms": [
+        20
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -111991,6 +118190,9 @@
       ],
       "name": "Chibi-Robo!: Park Patrol",
       "parent_game": -1,
+      "platforms": [
+        20
+      ],
       "player_perspectives": [
         2
       ],
@@ -112046,6 +118248,11 @@
       ],
       "name": "Defend Your Castle",
       "parent_game": -1,
+      "platforms": [
+        5,
+        6,
+        130
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -112109,6 +118316,9 @@
       ],
       "name": "Ninja Gaiden: Dragon Sword",
       "parent_game": -1,
+      "platforms": [
+        20
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -112158,6 +118368,9 @@
       ],
       "name": "Exit DS",
       "parent_game": 85653,
+      "platforms": [
+        20
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -112203,6 +118416,11 @@
       "keywords": [],
       "name": "LostWinds",
       "parent_game": -1,
+      "platforms": [
+        5,
+        6,
+        39
+      ],
       "player_perspectives": [
         4
       ],
@@ -112258,6 +118476,10 @@
       ],
       "name": "Resident Evil 4: Wii Edition",
       "parent_game": 974,
+      "platforms": [
+        5,
+        41
+      ],
       "player_perspectives": [
         2
       ],
@@ -112317,6 +118539,15 @@
       ],
       "name": "Middle-earth: Shadow of Mordor - The Bright Lord",
       "parent_game": 3025,
+      "platforms": [
+        3,
+        6,
+        9,
+        12,
+        14,
+        48,
+        49
+      ],
       "player_perspectives": [
         2
       ],
@@ -112377,6 +118608,14 @@
       "keywords": [],
       "name": "Phoenix Wright: Ace Attorney Trilogy",
       "parent_game": -1,
+      "platforms": [
+        6,
+        37,
+        39,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -112430,6 +118669,9 @@
       "keywords": [],
       "name": "Magicka: Vietnam",
       "parent_game": 2042,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -112465,6 +118707,9 @@
       "keywords": [],
       "name": "Space Invaders Get Even",
       "parent_game": -1,
+      "platforms": [
+        5
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -112535,6 +118780,9 @@
       ],
       "name": "Pop",
       "parent_game": -1,
+      "platforms": [
+        5
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -112589,6 +118837,11 @@
       ],
       "name": "Super Daryl Deluxe",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -112638,6 +118891,13 @@
       "keywords": [],
       "name": "Saints Row IV: Enter the Dominatrix",
       "parent_game": 1981,
+      "platforms": [
+        3,
+        6,
+        9,
+        12,
+        48
+      ],
       "player_perspectives": [
         2
       ],
@@ -112688,6 +118948,9 @@
       ],
       "name": "Picross e",
       "parent_game": -1,
+      "platforms": [
+        37
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -112733,6 +118996,9 @@
       "name": "Bomberman",
       "name_glogAppendReleaseYear": true,
       "parent_game": -1,
+      "platforms": [
+        20
+      ],
       "player_perspectives": [
         3
       ],
@@ -112845,6 +119111,10 @@
       ],
       "name": "Super Mario 64 DS",
       "parent_game": 1074,
+      "platforms": [
+        20,
+        41
+      ],
       "player_perspectives": [
         2
       ],
@@ -112905,6 +119175,9 @@
       "keywords": [],
       "name": "Rise of Nations: Extended Edition",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [
         3
       ],
@@ -112942,6 +119215,9 @@
       "keywords": [],
       "name": "Magicka: The Stars are Left",
       "parent_game": 2042,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -112989,6 +119265,13 @@
       ],
       "name": "Replay: VHS is not dead",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14,
+        41,
+        48,
+        49
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -113043,6 +119326,11 @@
       ],
       "name": "TIS-100",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         5
       ],
@@ -113092,6 +119380,13 @@
       ],
       "name": "Book of Demons",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         3
       ],
@@ -113153,6 +119448,12 @@
       ],
       "name": "The Sexy Brutale",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         3
       ],
@@ -113204,6 +119505,9 @@
       ],
       "name": "Champions of Anteria",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [
         3
       ],
@@ -113240,6 +119544,9 @@
       "keywords": [],
       "name": "Red Faction: Guerrilla - Demons of the Badlands",
       "parent_game": 846,
+      "platforms": [
+        12
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -113282,6 +119589,9 @@
       ],
       "name": "Hard Truck: Apocalypse",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -113334,6 +119644,9 @@
       ],
       "name": "Planet Puzzle League",
       "parent_game": -1,
+      "platforms": [
+        20
+      ],
       "player_perspectives": [
         4
       ],
@@ -113371,6 +119684,7 @@
       "keywords": [],
       "name": "Maelstrom",
       "parent_game": -1,
+      "platforms": [],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [],
@@ -113415,6 +119729,13 @@
       ],
       "name": "Saints Row IV: How the Saints Save Christmas",
       "parent_game": 1981,
+      "platforms": [
+        6,
+        9,
+        12,
+        48,
+        49
+      ],
       "player_perspectives": [
         2
       ],
@@ -113487,6 +119808,12 @@
       ],
       "name": "Battle Chef Brigade",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -113546,6 +119873,10 @@
       ],
       "name": "Sonic Adventure DX: Director's Cut",
       "parent_game": 7860,
+      "platforms": [
+        6,
+        21
+      ],
       "player_perspectives": [
         2
       ],
@@ -113607,6 +119938,14 @@
       "keywords": [],
       "name": "SteamWorld Heist: The Outsider",
       "parent_game": 15167,
+      "platforms": [
+        3,
+        6,
+        14,
+        37,
+        46,
+        48
+      ],
       "player_perspectives": [
         4
       ],
@@ -113668,6 +120007,11 @@
       ],
       "name": "Hackmud",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         5
       ],
@@ -113714,6 +120058,13 @@
       "keywords": [],
       "name": "Deus Ex: Mankind Divided - System Rift",
       "parent_game": 9498,
+      "platforms": [
+        3,
+        6,
+        14,
+        48,
+        49
+      ],
       "player_perspectives": [
         1
       ],
@@ -113779,6 +120130,13 @@
       ],
       "name": "Masquerada: Songs and Shadows",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         3
       ],
@@ -113837,6 +120195,12 @@
       ],
       "name": "Sorcery! Parts 1 & 2",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14,
+        34,
+        39
+      ],
       "player_perspectives": [
         5
       ],
@@ -113888,6 +120252,12 @@
       ],
       "name": "Beglitched",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        39
+      ],
       "player_perspectives": [
         1,
         4
@@ -113950,6 +120320,11 @@
       ],
       "name": "Phoenix Wright: Ace Attorney - Dual Destinies: Special Episode - Turnabout Reclaimed",
       "parent_game": 1432,
+      "platforms": [
+        34,
+        37,
+        39
+      ],
       "player_perspectives": [
         4
       ],
@@ -114031,6 +120406,12 @@
       ],
       "name": "Red Dead Redemption 2",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49,
+        170
+      ],
       "player_perspectives": [
         1,
         2
@@ -114103,6 +120484,13 @@
       ],
       "name": "Darksiders: Warmastered Edition",
       "parent_game": 1270,
+      "platforms": [
+        6,
+        41,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         2
       ],
@@ -114164,6 +120552,11 @@
       ],
       "name": "Shenzhen I/O",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         3
       ],
@@ -114222,6 +120615,11 @@
       ],
       "name": "SquareCells",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -114265,6 +120663,11 @@
       ],
       "name": "Desert Bus",
       "parent_game": -1,
+      "platforms": [
+        34,
+        78,
+        82
+      ],
       "player_perspectives": [
         1
       ],
@@ -114315,6 +120718,15 @@
       ],
       "name": "The Pedestrian",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14,
+        48,
+        49,
+        130,
+        167,
+        169
+      ],
       "player_perspectives": [
         4
       ],
@@ -114367,6 +120779,9 @@
       ],
       "name": "Escape the Game",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [
         4
       ],
@@ -114420,6 +120835,11 @@
       ],
       "name": "Batman: Arkham Knight - Harley Quinn Story Pack",
       "parent_game": 5503,
+      "platforms": [
+        6,
+        48,
+        49
+      ],
       "player_perspectives": [
         2
       ],
@@ -114473,6 +120893,10 @@
       ],
       "name": "Sethian",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14
+      ],
       "player_perspectives": [
         4
       ],
@@ -114540,6 +120964,9 @@
       ],
       "name": "Uncharted: The Lost Legacy",
       "parent_game": 7331,
+      "platforms": [
+        48
+      ],
       "player_perspectives": [
         2
       ],
@@ -114615,6 +121042,15 @@
       ],
       "name": "Celeste",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        48,
+        49,
+        130,
+        170
+      ],
       "player_perspectives": [
         4
       ],
@@ -114681,6 +121117,14 @@
       ],
       "name": "Splasher",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -114779,6 +121223,14 @@
       ],
       "name": "Disco Elysium",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14,
+        48,
+        130,
+        167,
+        170
+      ],
       "player_perspectives": [
         3,
         5
@@ -114831,6 +121283,11 @@
       ],
       "name": "Glittermitten Grove",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         4
       ],
@@ -114879,6 +121336,11 @@
       "keywords": [],
       "name": "Last Word",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         3
       ],
@@ -114930,6 +121392,11 @@
       ],
       "name": "Pictopix",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -115014,6 +121481,9 @@
       ],
       "name": "Super Mario Odyssey",
       "parent_game": -1,
+      "platforms": [
+        130
+      ],
       "player_perspectives": [
         2
       ],
@@ -115062,6 +121532,12 @@
       ],
       "name": "Mark of the Ninja: Special Edition DLC",
       "parent_game": 2129,
+      "platforms": [
+        3,
+        6,
+        12,
+        14
+      ],
       "player_perspectives": [
         4
       ],
@@ -115114,6 +121590,13 @@
       ],
       "name": "Deus Ex: Mankind Divided - A Criminal Past",
       "parent_game": 9498,
+      "platforms": [
+        3,
+        6,
+        14,
+        48,
+        49
+      ],
       "player_perspectives": [
         1
       ],
@@ -115185,6 +121668,16 @@
       ],
       "name": "Minit",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        34,
+        39,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         3
       ],
@@ -115255,6 +121748,15 @@
       ],
       "name": "Death Squared",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        34,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         3
       ],
@@ -115317,6 +121819,14 @@
       ],
       "name": "Linelight",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        48,
+        130,
+        384
+      ],
       "player_perspectives": [
         4
       ],
@@ -115382,6 +121892,13 @@
       ],
       "name": "Stories Untold",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         5
       ],
@@ -115441,6 +121958,13 @@
       ],
       "name": "Deep Rock Galactic",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49,
+        167,
+        169
+      ],
       "player_perspectives": [
         1
       ],
@@ -115495,6 +122019,11 @@
       ],
       "name": "Code 7",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         3,
         5
@@ -115549,6 +122078,17 @@
       ],
       "name": "Forma.8",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14,
+        34,
+        39,
+        41,
+        46,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -115614,6 +122154,12 @@
       ],
       "name": "Yoku's Island Express",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -115711,6 +122257,11 @@
       ],
       "name": "Middle-earth: Shadow of War",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49
+      ],
       "player_perspectives": [
         2
       ],
@@ -115779,6 +122330,14 @@
       ],
       "name": "Cosmic Star Heroine",
       "parent_game": -1,
+      "platforms": [
+        6,
+        46,
+        48,
+        49,
+        130,
+        170
+      ],
       "player_perspectives": [
         3
       ],
@@ -115839,6 +122398,10 @@
       ],
       "name": "NITE Team 4",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14
+      ],
       "player_perspectives": [
         5
       ],
@@ -115891,6 +122454,11 @@
       ],
       "name": "Hacknet: Labyrinths",
       "parent_game": 11707,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         5
       ],
@@ -115949,6 +122517,16 @@
       ],
       "name": "Planescape: Torment - Enhanced Edition",
       "parent_game": 832,
+      "platforms": [
+        3,
+        6,
+        14,
+        34,
+        39,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         3
       ],
@@ -116024,6 +122602,13 @@
       ],
       "name": "Darksiders III",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49,
+        130,
+        170
+      ],
       "player_perspectives": [
         2
       ],
@@ -116111,6 +122696,9 @@
       ],
       "name": "Mario + Rabbids Kingdom Battle",
       "parent_game": -1,
+      "platforms": [
+        130
+      ],
       "player_perspectives": [
         3
       ],
@@ -116161,6 +122749,10 @@
       "keywords": [],
       "name": "Nadia Was Here",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -116254,6 +122846,14 @@
       ],
       "name": "Assassin's Creed Origins",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49,
+        167,
+        169,
+        170
+      ],
       "player_perspectives": [
         2
       ],
@@ -116310,6 +122910,11 @@
       ],
       "name": "CrossCells",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         4
       ],
@@ -116379,6 +122984,15 @@
       ],
       "name": "Timespinner",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        46,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -116431,6 +123045,12 @@
       ],
       "name": "Strong Bad's Cool Game for Attractive People Episode 1: Homestar Ruiner",
       "parent_game": 9463,
+      "platforms": [
+        5,
+        6,
+        9,
+        14
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -116470,6 +123090,9 @@
       "keywords": [],
       "name": "Glyphs Apprentice",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -116524,6 +123147,10 @@
       ],
       "name": "Miner Ultra Adventures",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6
+      ],
       "player_perspectives": [
         2
       ],
@@ -116566,6 +123193,11 @@
       "keywords": [],
       "name": "MHRD",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -116619,6 +123251,13 @@
       ],
       "name": "Transcripted",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         3
       ],
@@ -116672,6 +123311,10 @@
       "keywords": [],
       "name": "Adventure Time: Finn and Jake's Epic Quest",
       "parent_game": -1,
+      "platforms": [
+        6,
+        82
+      ],
       "player_perspectives": [
         3
       ],
@@ -116714,6 +123357,10 @@
       "keywords": [],
       "name": "Red Spider 2: Exiled",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -116752,6 +123399,10 @@
       "keywords": [],
       "name": "Red Spider: Vengeance",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -116793,6 +123444,10 @@
       ],
       "name": "Phrase Shift",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -116837,6 +123492,11 @@
       ],
       "name": "Recursed",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         4
       ],
@@ -116897,6 +123557,10 @@
       ],
       "name": "LaserCat",
       "parent_game": -1,
+      "platforms": [
+        6,
+        12
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -116940,6 +123604,9 @@
       "keywords": [],
       "name": "Khimera: Destroy All Monster Girls",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -116989,6 +123656,11 @@
       ],
       "name": "Pitfall Planet",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14,
+        130
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -117034,6 +123706,9 @@
       ],
       "name": "3030 Deathwar Redux",
       "parent_game": 170080,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [
         3,
         4
@@ -117083,6 +123758,11 @@
       ],
       "name": "Pocket Kingdom",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -117132,6 +123812,10 @@
       ],
       "name": "Mandagon",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -117171,6 +123855,11 @@
       "keywords": [],
       "name": "Regeria Hope Episode 1",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         5
       ],
@@ -117217,6 +123906,11 @@
       "keywords": [],
       "name": "Dyadic",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14,
+        130
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -117269,6 +123963,13 @@
       "keywords": [],
       "name": "BioShock Remastered",
       "parent_game": 20,
+      "platforms": [
+        6,
+        14,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         1
       ],
@@ -117334,6 +124035,13 @@
       "keywords": [],
       "name": "BioShock 2 Remastered",
       "parent_game": 21,
+      "platforms": [
+        6,
+        14,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         1
       ],
@@ -117395,6 +124103,15 @@
       ],
       "name": "Iconoclasts",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        46,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -117444,6 +124161,10 @@
       ],
       "name": "Spooky Cats",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -117511,6 +124232,15 @@
       ],
       "name": "CrossCode",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        48,
+        49,
+        130,
+        167
+      ],
       "player_perspectives": [
         3
       ],
@@ -117566,6 +124296,10 @@
       ],
       "name": "Why Am I Dead At Sea",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14
+      ],
       "player_perspectives": [
         3
       ],
@@ -117615,6 +124349,13 @@
       ],
       "name": "Galacide",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -117665,6 +124406,11 @@
       "keywords": [],
       "name": "Regency Solitaire",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14,
+        130
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -117712,6 +124458,12 @@
       "keywords": [],
       "name": "HeartZ: Co-Hope Puzzles",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        49
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -117766,6 +124518,16 @@
       ],
       "name": "Shadowrun: Hong Kong - Extended Edition",
       "parent_game": 11772,
+      "platforms": [
+        3,
+        6,
+        14,
+        48,
+        49,
+        130,
+        167,
+        169
+      ],
       "player_perspectives": [
         3
       ],
@@ -117814,6 +124576,10 @@
       "keywords": [],
       "name": "Star Nomad",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -117855,6 +124621,10 @@
       ],
       "name": "Words for Evil",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14
+      ],
       "player_perspectives": [
         5
       ],
@@ -117914,6 +124684,10 @@
       ],
       "name": "Prelogate",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -117961,6 +124735,11 @@
       ],
       "name": "Volt",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -118006,6 +124785,16 @@
       "keywords": [],
       "name": "Shantae: Risky's Revenge - Director's Cut",
       "parent_game": -1,
+      "platforms": [
+        6,
+        41,
+        46,
+        48,
+        49,
+        130,
+        167,
+        170
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -118062,6 +124851,11 @@
       ],
       "name": "Last Day of June",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        130
+      ],
       "player_perspectives": [
         2
       ],
@@ -118116,6 +124910,14 @@
       "keywords": [],
       "name": "Cat Quest",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14,
+        34,
+        39,
+        48,
+        130
+      ],
       "player_perspectives": [
         2
       ],
@@ -118173,6 +124975,11 @@
       ],
       "name": "Extinction",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -118220,6 +125027,14 @@
       "keywords": [],
       "name": "Underhero",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -118283,6 +125098,11 @@
       ],
       "name": "A Way Out",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49
+      ],
       "player_perspectives": [
         2
       ],
@@ -118364,6 +125184,12 @@
       ],
       "name": "Wolfenstein II: The New Colossus",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         1
       ],
@@ -118425,6 +125251,12 @@
       ],
       "name": "Ori and the Will of the Wisps",
       "parent_game": -1,
+      "platforms": [
+        6,
+        49,
+        130,
+        169
+      ],
       "player_perspectives": [
         4
       ],
@@ -118512,6 +125344,11 @@
       ],
       "name": "Dishonored: Death of the Outsider",
       "parent_game": 11118,
+      "platforms": [
+        6,
+        48,
+        49
+      ],
       "player_perspectives": [
         1
       ],
@@ -118567,6 +125404,10 @@
       ],
       "name": "Horizon Zero Dawn: The Frozen Wilds",
       "parent_game": 11156,
+      "platforms": [
+        6,
+        48
+      ],
       "player_perspectives": [
         2
       ],
@@ -118624,6 +125465,9 @@
       "name": "Shadow of the Colossus",
       "name_glogAppendReleaseYear": true,
       "parent_game": 2207,
+      "platforms": [
+        48
+      ],
       "player_perspectives": [
         2
       ],
@@ -118683,6 +125527,9 @@
       ],
       "name": "Metroid Prime 4: Beyond",
       "parent_game": -1,
+      "platforms": [
+        130
+      ],
       "player_perspectives": [
         1
       ],
@@ -118746,6 +125593,9 @@
       ],
       "name": "Metroid: Samus Returns",
       "parent_game": 1102,
+      "platforms": [
+        37
+      ],
       "player_perspectives": [
         4
       ],
@@ -118816,6 +125666,15 @@
       ],
       "name": "Shadow of the Tomb Raider",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        48,
+        49,
+        169,
+        170
+      ],
       "player_perspectives": [
         2
       ],
@@ -118871,6 +125730,14 @@
       "keywords": [],
       "name": "Beat Hazard Ultra",
       "parent_game": 7404,
+      "platforms": [
+        3,
+        6,
+        9,
+        14,
+        34,
+        39
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -118921,6 +125788,10 @@
       "keywords": [],
       "name": "The Legend of Zelda: Breath of the Wild - The Master Trials",
       "parent_game": 7346,
+      "platforms": [
+        41,
+        130
+      ],
       "player_perspectives": [
         2
       ],
@@ -118972,6 +125843,10 @@
       ],
       "name": "The Legend of Zelda: Breath of the Wild - The Champions' Ballad",
       "parent_game": 7346,
+      "platforms": [
+        41,
+        130
+      ],
       "player_perspectives": [
         2
       ],
@@ -119028,6 +125903,11 @@
       ],
       "name": "Bomberman '93",
       "parent_game": -1,
+      "platforms": [
+        5,
+        6,
+        86
+      ],
       "player_perspectives": [
         3
       ],
@@ -119088,6 +125968,9 @@
       ],
       "name": "Doubutsu no Mori",
       "parent_game": -1,
+      "platforms": [
+        4
+      ],
       "player_perspectives": [
         3
       ],
@@ -119147,6 +126030,10 @@
       ],
       "name": "The Legend of Zelda: Ocarina of Time - Master Quest",
       "parent_game": 1029,
+      "platforms": [
+        21,
+        416
+      ],
       "player_perspectives": [
         2
       ],
@@ -119203,6 +126090,10 @@
       ],
       "name": "The Legend of Zelda: Four Swords - Anniversary Edition",
       "parent_game": 163572,
+      "platforms": [
+        37,
+        159
+      ],
       "player_perspectives": [
         3
       ],
@@ -119255,6 +126146,9 @@
       ],
       "name": "Crosswords DS",
       "parent_game": -1,
+      "platforms": [
+        20
+      ],
       "player_perspectives": [
         1
       ],
@@ -119292,6 +126186,9 @@
       "keywords": [],
       "name": "Gunpey DS",
       "parent_game": -1,
+      "platforms": [
+        20
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -119354,6 +126251,9 @@
       ],
       "name": "Mario vs. Donkey Kong: Minis March Again!",
       "parent_game": -1,
+      "platforms": [
+        159
+      ],
       "player_perspectives": [
         4
       ],
@@ -119397,6 +126297,9 @@
       ],
       "name": "Lee Trevino's Fighting Golf",
       "parent_game": -1,
+      "platforms": [
+        18
+      ],
       "player_perspectives": [],
       "ports": [
         40042,
@@ -119446,6 +126349,9 @@
       ],
       "name": "Escape Velocity Nova",
       "parent_game": -1,
+      "platforms": [
+        14
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -119510,6 +126416,14 @@
       ],
       "name": "Shaq Fu: A Legend Reborn",
       "parent_game": -1,
+      "platforms": [
+        6,
+        34,
+        39,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -119582,6 +126496,15 @@
       ],
       "name": "Trine Enchanted Edition",
       "parent_game": 6247,
+      "platforms": [
+        3,
+        6,
+        14,
+        41,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -119630,6 +126553,9 @@
       "keywords": [],
       "name": "Pepper's Puzzles",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -119689,6 +126615,12 @@
       ],
       "name": "The LEGO Ninjago Movie Video Game",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         2
       ],
@@ -119730,6 +126662,7 @@
       "keywords": [],
       "name": "Luminesca",
       "parent_game": -1,
+      "platforms": [],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [],
@@ -119771,6 +126704,15 @@
       "keywords": [],
       "name": "Middle-earth: Shadow of Mordor - Lord of the Hunt",
       "parent_game": 3025,
+      "platforms": [
+        3,
+        6,
+        9,
+        12,
+        14,
+        48,
+        49
+      ],
       "player_perspectives": [
         2
       ],
@@ -119818,6 +126760,9 @@
       "keywords": [],
       "name": "InfiniPicross",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -119864,6 +126809,9 @@
       "keywords": [],
       "name": "Final Fantasy XV: Windows Edition",
       "parent_game": 359,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [
         2
       ],
@@ -119919,6 +126867,11 @@
       ],
       "name": "Semblance",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -119964,6 +126917,11 @@
       "keywords": [],
       "name": "Silicon Zeroes",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -120008,6 +126966,9 @@
       ],
       "name": "Alchemia",
       "parent_game": -1,
+      "platforms": [
+        82
+      ],
       "player_perspectives": [
         4
       ],
@@ -120055,6 +127016,9 @@
       ],
       "name": "My Nintendo Picross: The Legend of Zelda Twilight Princess",
       "parent_game": -1,
+      "platforms": [
+        37
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -120099,6 +127063,11 @@
       ],
       "name": "Elsinore",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         3
       ],
@@ -120148,6 +127117,10 @@
       ],
       "name": "Grapple Force Rena",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6
+      ],
       "player_perspectives": [
         4
       ],
@@ -120195,6 +127168,9 @@
       ],
       "name": "20,000 Leagues Above the Clouds",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -120237,6 +127213,9 @@
       ],
       "name": "The Tower DS",
       "parent_game": -1,
+      "platforms": [
+        20
+      ],
       "player_perspectives": [
         4
       ],
@@ -120282,6 +127261,7 @@
       ],
       "name": "Civilization Online",
       "parent_game": -1,
+      "platforms": [],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [],
@@ -120336,6 +127316,9 @@
       ],
       "name": "BioShock Infinite: Industrial Revolution",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [
         3
       ],
@@ -120382,6 +127365,9 @@
       ],
       "name": "Picross e2",
       "parent_game": -1,
+      "platforms": [
+        37
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -120427,6 +127413,9 @@
       ],
       "name": "Techno Kitten Adventure",
       "parent_game": -1,
+      "platforms": [
+        12
+      ],
       "player_perspectives": [
         4
       ],
@@ -120480,6 +127469,12 @@
       ],
       "name": "Zone of The Enders: The 2nd Runner Mars",
       "parent_game": 1473,
+      "platforms": [
+        6,
+        48,
+        162,
+        165
+      ],
       "player_perspectives": [
         7
       ],
@@ -120539,6 +127534,13 @@
       "keywords": [],
       "name": "Mugsters",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -120589,6 +127591,15 @@
       ],
       "name": "Raji: An Ancient Epic",
       "parent_game": -1,
+      "platforms": [
+        6,
+        34,
+        39,
+        48,
+        49,
+        130,
+        167
+      ],
       "player_perspectives": [
         2
       ],
@@ -120652,6 +127663,12 @@
       ],
       "name": "Famicom Wars",
       "parent_game": -1,
+      "platforms": [
+        5,
+        37,
+        41,
+        99
+      ],
       "player_perspectives": [
         3
       ],
@@ -120700,6 +127717,9 @@
       ],
       "name": "Escape Velocity",
       "parent_game": -1,
+      "platforms": [
+        14
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -120763,6 +127783,13 @@
       ],
       "name": "Untitled Goose Game",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         3
       ],
@@ -120822,6 +127849,10 @@
       ],
       "name": "The Warlock of Firetop Mountain",
       "parent_game": -1,
+      "platforms": [
+        6,
+        130
+      ],
       "player_perspectives": [],
       "ports": [
         200318
@@ -120882,6 +127913,12 @@
       ],
       "name": "Opus Magnum",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        49
+      ],
       "player_perspectives": [
         3
       ],
@@ -120940,6 +127977,14 @@
       ],
       "name": "Star Wars Jedi: Fallen Order",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49,
+        167,
+        169,
+        170
+      ],
       "player_perspectives": [
         2
       ],
@@ -121003,6 +128048,9 @@
       ],
       "name": "Ghost of Tsushima",
       "parent_game": -1,
+      "platforms": [
+        48
+      ],
       "player_perspectives": [
         2
       ],
@@ -121056,6 +128104,10 @@
       "keywords": [],
       "name": "Ittle Dew 2+",
       "parent_game": 11598,
+      "platforms": [
+        6,
+        130
+      ],
       "player_perspectives": [
         3
       ],
@@ -121134,6 +128186,14 @@
       ],
       "name": "The Great Ace Attorney: Adventures",
       "parent_game": -1,
+      "platforms": [
+        6,
+        34,
+        37,
+        39,
+        48,
+        130
+      ],
       "player_perspectives": [
         1,
         2,
@@ -121205,6 +128265,14 @@
       ],
       "name": "Baba is You",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        34,
+        39,
+        130
+      ],
       "player_perspectives": [
         3
       ],
@@ -121259,6 +128327,13 @@
       "keywords": [],
       "name": "Adventure Time: Pirates of the Enchiridion",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49,
+        130,
+        170
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -121313,6 +128388,13 @@
       ],
       "name": "Afterparty",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -121382,6 +128464,11 @@
       ],
       "name": "SpaceChem: 63 Corvi",
       "parent_game": 8390,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         3
       ],
@@ -121429,6 +128516,9 @@
       "keywords": [],
       "name": "Sleeping Dogs: Wheels of Fury",
       "parent_game": 1267,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [
         2
       ],
@@ -121474,6 +128564,10 @@
       "keywords": [],
       "name": "Sleeping Dogs: Zodiac Tournament",
       "parent_game": 1267,
+      "platforms": [
+        6,
+        9
+      ],
       "player_perspectives": [
         2
       ],
@@ -121527,6 +128621,13 @@
       "keywords": [],
       "name": "BioShock 2: Minerva's Den Remastered",
       "parent_game": 34294,
+      "platforms": [
+        6,
+        14,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         1
       ],
@@ -121578,6 +128679,11 @@
       "keywords": [],
       "name": "Saints Row: The Third - The Trouble with Clones",
       "parent_game": 873,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -121624,6 +128730,11 @@
       "keywords": [],
       "name": "Saints Row: The Third - Gangstas in Space",
       "parent_game": 873,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -121666,6 +128777,11 @@
       "keywords": [],
       "name": "Saints Row: The Third - Genkibowl VII",
       "parent_game": 873,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -121712,6 +128828,9 @@
       "keywords": [],
       "name": "Red Faction: Armageddon - Path to War",
       "parent_game": 528,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -121757,6 +128876,10 @@
       ],
       "name": "Monkey Wrench",
       "parent_game": -1,
+      "platforms": [
+        34,
+        39
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -121800,6 +128923,9 @@
       "keywords": [],
       "name": "Warlock: Master of the Arcane - Armageddon",
       "parent_game": 2072,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [
         3
       ],
@@ -121869,6 +128995,9 @@
       ],
       "name": "Half-Minute Hero: Super Mega Neo Climax",
       "parent_game": 21943,
+      "platforms": [
+        12
+      ],
       "player_perspectives": [
         3,
         4
@@ -121923,6 +129052,9 @@
       ],
       "name": "Divinity II: Developer's Cut",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [
         2
       ],
@@ -121974,6 +129106,11 @@
       "keywords": [],
       "name": "Mass Effect 3: Extended Cut",
       "parent_game": 75,
+      "platforms": [
+        6,
+        9,
+        12
+      ],
       "player_perspectives": [
         2
       ],
@@ -122031,6 +129168,11 @@
       ],
       "name": "Phoenix Wright: Ace Attorney - Spirit of Justice: Special Episode - Turnabout Time Traveler",
       "parent_game": 12077,
+      "platforms": [
+        34,
+        37,
+        39
+      ],
       "player_perspectives": [
         1,
         2,
@@ -122088,6 +129230,9 @@
       ],
       "name": "Phoenix Wright: Ace Attorney - Spirit of Justice: Phoenix Wright - Asinine Attorney",
       "parent_game": 12077,
+      "platforms": [
+        37
+      ],
       "player_perspectives": [
         1,
         2,
@@ -122143,6 +129288,9 @@
       ],
       "name": "Phoenix Wright: Ace Attorney - Spirit of Justice: Apollo Justice - Asinine Attorney",
       "parent_game": 12077,
+      "platforms": [
+        37
+      ],
       "player_perspectives": [
         1,
         2,
@@ -122202,6 +129350,11 @@
       ],
       "name": "The Talos Principle II",
       "parent_game": -1,
+      "platforms": [
+        6,
+        167,
+        169
+      ],
       "player_perspectives": [
         1,
         2
@@ -122290,6 +129443,9 @@
       ],
       "name": "StreetPass Mii Plaza",
       "parent_game": -1,
+      "platforms": [
+        37
+      ],
       "player_perspectives": [
         2
       ],
@@ -122343,6 +129499,12 @@
       ],
       "name": "Omensight",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         2,
         3
@@ -122392,6 +129554,10 @@
       "keywords": [],
       "name": "Tales of Monkey Island: Chapter 1 - Launch of the Screaming Narwhal",
       "parent_game": 64,
+      "platforms": [
+        5,
+        6
+      ],
       "player_perspectives": [
         2
       ],
@@ -122437,6 +129603,9 @@
       "keywords": [],
       "name": "Algo Bot",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -122522,6 +129691,11 @@
       "keywords": [],
       "name": "Forza Horizon 4",
       "parent_game": -1,
+      "platforms": [
+        6,
+        49,
+        169
+      ],
       "player_perspectives": [
         1,
         2
@@ -122574,6 +129748,13 @@
       ],
       "name": "Mindustry",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        34,
+        39
+      ],
       "player_perspectives": [
         3
       ],
@@ -122629,6 +129810,14 @@
       ],
       "name": "7 Billion Humans",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        34,
+        39,
+        130
+      ],
       "player_perspectives": [
         3
       ],
@@ -122681,6 +129870,9 @@
       "keywords": [],
       "name": "Dyo",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [
         4
       ],
@@ -122758,6 +129950,13 @@
       ],
       "name": "Panel de Pon",
       "parent_game": -1,
+      "platforms": [
+        5,
+        41,
+        58,
+        137,
+        306
+      ],
       "player_perspectives": [
         4
       ],
@@ -122819,6 +130018,9 @@
       ],
       "name": "Tactical Breach Wizards",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [
         3
       ],
@@ -122872,6 +130074,11 @@
       "name": "Cypher",
       "name_glogAppendReleaseYear": true,
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         1
       ],
@@ -122913,6 +130120,9 @@
       "keywords": [],
       "name": "Nonogram - The Greatest Painter",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -123015,6 +130225,9 @@
       ],
       "name": "Super Smash Bros. Ultimate",
       "parent_game": -1,
+      "platforms": [
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -123066,6 +130279,11 @@
       ],
       "name": "Satisfactory",
       "parent_game": -1,
+      "platforms": [
+        6,
+        167,
+        169
+      ],
       "player_perspectives": [
         1
       ],
@@ -123118,6 +130336,12 @@
       "name": "Eliza",
       "name_glogAppendReleaseYear": true,
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        130
+      ],
       "player_perspectives": [
         1
       ],
@@ -123171,6 +130395,9 @@
       ],
       "name": "Cubots: The Origins",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -123217,6 +130444,14 @@
       ],
       "name": "Mark of the Ninja Remastered",
       "parent_game": 2129,
+      "platforms": [
+        3,
+        6,
+        14,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -123286,6 +130521,12 @@
       ],
       "name": "Red Faction: Guerrilla Re-Mars-tered",
       "parent_game": 846,
+      "platforms": [
+        6,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         2
       ],
@@ -123333,6 +130574,12 @@
       "keywords": [],
       "name": "South Park: The Fractured But Whole - From Dusk Till Casa Bonita",
       "parent_game": 11161,
+      "platforms": [
+        6,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -123388,6 +130635,17 @@
       ],
       "name": "Inked",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14,
+        34,
+        39,
+        48,
+        49,
+        130,
+        167,
+        169
+      ],
       "player_perspectives": [
         3
       ],
@@ -123448,6 +130706,10 @@
       ],
       "name": "Starfield",
       "parent_game": -1,
+      "platforms": [
+        6,
+        169
+      ],
       "player_perspectives": [
         1,
         2
@@ -123505,6 +130767,9 @@
       ],
       "name": "Prime Mover",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [
         3
       ],
@@ -123545,6 +130810,7 @@
       "keywords": [],
       "name": "Mutants Must Die!",
       "parent_game": -1,
+      "platforms": [],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [],
@@ -123592,6 +130858,12 @@
       ],
       "name": "Cube Escape: Paradox",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14,
+        34,
+        39
+      ],
       "player_perspectives": [
         1,
         4
@@ -123651,6 +130923,14 @@
       ],
       "name": "Bloodstained: Curse of the Moon",
       "parent_game": -1,
+      "platforms": [
+        6,
+        37,
+        46,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -123714,6 +130994,12 @@
       ],
       "name": "Rage 2",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49,
+        170
+      ],
       "player_perspectives": [
         1
       ],
@@ -123774,6 +131060,14 @@
       ],
       "name": "Toodee and Topdee",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49,
+        130,
+        167,
+        169
+      ],
       "player_perspectives": [
         3,
         4
@@ -123835,6 +131129,13 @@
       ],
       "name": "Cat Quest II",
       "parent_game": -1,
+      "platforms": [
+        6,
+        39,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         2,
         3
@@ -123883,6 +131184,9 @@
       "keywords": [],
       "name": "Picross Fairytale",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -123931,6 +131235,11 @@
       "keywords": [],
       "name": "Gears 5",
       "parent_game": -1,
+      "platforms": [
+        6,
+        49,
+        169
+      ],
       "player_perspectives": [
         2
       ],
@@ -123991,6 +131300,11 @@
       ],
       "name": "Prey: Mooncrash",
       "parent_game": 19531,
+      "platforms": [
+        6,
+        48,
+        49
+      ],
       "player_perspectives": [
         1
       ],
@@ -124040,6 +131354,13 @@
       "keywords": [],
       "name": "Neo Cab",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        39,
+        130
+      ],
       "player_perspectives": [
         2
       ],
@@ -124101,6 +131422,14 @@
       ],
       "name": "The Forgotten City",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14,
+        48,
+        49,
+        167,
+        169
+      ],
       "player_perspectives": [
         1
       ],
@@ -124185,6 +131514,14 @@
       ],
       "name": "Control",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49,
+        167,
+        169,
+        170
+      ],
       "player_perspectives": [
         2
       ],
@@ -124255,6 +131592,9 @@
       ],
       "name": "Super Mario Party",
       "parent_game": -1,
+      "platforms": [
+        130
+      ],
       "player_perspectives": [
         3
       ],
@@ -124302,6 +131642,10 @@
       ],
       "name": "Hungry Cat Picross",
       "parent_game": -1,
+      "platforms": [
+        34,
+        39
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -124339,6 +131683,12 @@
       "keywords": [],
       "name": "South Park: The Fractured But Whole - Bring the Crunch",
       "parent_game": 11161,
+      "platforms": [
+        6,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -124383,6 +131733,11 @@
       "keywords": [],
       "name": "Exapunks",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         3
       ],
@@ -124434,6 +131789,11 @@
       "keywords": [],
       "name": "The Textorcist: The Story of Ray Bibbia",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14,
+        23
+      ],
       "player_perspectives": [
         3
       ],
@@ -124492,6 +131852,14 @@
       ],
       "name": "Thronebreaker: The Witcher Tales",
       "parent_game": 19474,
+      "platforms": [
+        6,
+        34,
+        39,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         3
       ],
@@ -124551,6 +131919,11 @@
       ],
       "name": "Gato Roboto",
       "parent_game": -1,
+      "platforms": [
+        6,
+        49,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -124603,6 +131976,12 @@
       "keywords": [],
       "name": "Rebel Galaxy Outlaw",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         1,
         2
@@ -124668,6 +132047,13 @@
       ],
       "name": "Trine 4: The Nightmare Prince",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49,
+        130,
+        170
+      ],
       "player_perspectives": [
         4
       ],
@@ -124722,6 +132108,10 @@
       ],
       "name": "Brainfuck",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6
+      ],
       "player_perspectives": [
         5
       ],
@@ -124766,6 +132156,9 @@
       "keywords": [],
       "name": "Nonogram: Master's Legacy",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -124838,6 +132231,11 @@
       ],
       "name": "Horizon Forbidden West",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        167
+      ],
       "player_perspectives": [
         2
       ],
@@ -124925,6 +132323,11 @@
       ],
       "name": "God of War Ragnarök",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        167
+      ],
       "player_perspectives": [
         2
       ],
@@ -124981,6 +132384,12 @@
       ],
       "name": "Omensight: Definitive Edition",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -125046,6 +132455,16 @@
       "name": "Hades",
       "name_glogAppendReleaseYear": true,
       "parent_game": -1,
+      "platforms": [
+        6,
+        14,
+        39,
+        48,
+        49,
+        130,
+        167,
+        169
+      ],
       "player_perspectives": [
         3
       ],
@@ -125123,6 +132542,13 @@
       ],
       "name": "The Outer Worlds",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49,
+        130,
+        169
+      ],
       "player_perspectives": [
         1
       ],
@@ -125180,6 +132606,11 @@
       ],
       "name": "Lightmatter",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49
+      ],
       "player_perspectives": [
         1
       ],
@@ -125230,6 +132661,11 @@
       ],
       "name": "MO:Astray",
       "parent_game": -1,
+      "platforms": [
+        6,
+        39,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -125280,6 +132716,11 @@
       ],
       "name": "What Never Was",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         1
       ],
@@ -125347,6 +132788,11 @@
       ],
       "name": "Deathloop",
       "parent_game": -1,
+      "platforms": [
+        6,
+        167,
+        169
+      ],
       "player_perspectives": [
         1
       ],
@@ -125409,6 +132855,12 @@
       ],
       "name": "Moving Out",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         3
       ],
@@ -125461,6 +132913,14 @@
       "keywords": [],
       "name": "Roombo: First Blood",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14,
+        48,
+        49,
+        130,
+        169
+      ],
       "player_perspectives": [
         3
       ],
@@ -125520,6 +132980,16 @@
       ],
       "name": "Hollow Knight: Silksong",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        48,
+        49,
+        130,
+        167,
+        169
+      ],
       "player_perspectives": [
         4
       ],
@@ -125575,6 +133045,14 @@
       ],
       "name": "Eternal Threads",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49,
+        130,
+        167,
+        169
+      ],
       "player_perspectives": [
         1
       ],
@@ -125629,6 +133107,11 @@
       "keywords": [],
       "name": "Vampire: The Masquerade - Bloodlines 2",
       "parent_game": -1,
+      "platforms": [
+        6,
+        167,
+        169
+      ],
       "player_perspectives": [
         1
       ],
@@ -125681,6 +133164,14 @@
       ],
       "name": "The Lord of the Rings: Gollum",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49,
+        130,
+        167,
+        169
+      ],
       "player_perspectives": [
         2
       ],
@@ -125734,6 +133225,9 @@
       ],
       "name": "Burning Daylight",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [
         4
       ],
@@ -125782,6 +133276,12 @@
       ],
       "name": "Lair of the Clockwork God",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -125837,6 +133337,13 @@
       ],
       "name": "Drunken Fist",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49,
+        130,
+        167
+      ],
       "player_perspectives": [
         2,
         3
@@ -125893,6 +133400,16 @@
       "keywords": [],
       "name": "BioShock Infinite: Burial at Sea - Episode 2",
       "parent_game": 127036,
+      "platforms": [
+        3,
+        6,
+        9,
+        12,
+        14,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         1
       ],
@@ -125948,6 +133465,11 @@
       "keywords": [],
       "name": "Danger Crew",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -126043,6 +133565,13 @@
       ],
       "name": "Baldur's Gate 3",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14,
+        167,
+        169,
+        170
+      ],
       "player_perspectives": [
         3
       ],
@@ -126101,6 +133630,13 @@
       "keywords": [],
       "name": "Borderlands 2: Commander Lilith and the Fight for Sanctuary",
       "parent_game": 1011,
+      "platforms": [
+        6,
+        14,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         1
       ],
@@ -126163,6 +133699,15 @@
       ],
       "name": "Spiritfarer",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        48,
+        49,
+        130,
+        170
+      ],
       "player_perspectives": [
         4
       ],
@@ -126213,6 +133758,14 @@
       "keywords": [],
       "name": "No More Heroes III",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49,
+        130,
+        167,
+        169
+      ],
       "player_perspectives": [
         2
       ],
@@ -126283,6 +133836,9 @@
       ],
       "name": "The Legend of Zelda: Tears of the Kingdom",
       "parent_game": -1,
+      "platforms": [
+        130
+      ],
       "player_perspectives": [
         2
       ],
@@ -126336,6 +133892,12 @@
       ],
       "name": "Depixtion",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        130
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -126394,6 +133956,14 @@
       ],
       "name": "The Dungeon of Naheulbeuk: The Amulet of Chaos",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14,
+        48,
+        49,
+        130,
+        167
+      ],
       "player_perspectives": [
         3
       ],
@@ -126443,6 +134013,7 @@
       "keywords": [],
       "name": "Tales of Lazo",
       "parent_game": -1,
+      "platforms": [],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [],
@@ -126492,6 +134063,12 @@
       "keywords": [],
       "name": "Biped",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         2,
         4
@@ -126552,6 +134129,14 @@
       ],
       "name": "PictoQuest: The Cursed Grids",
       "parent_game": -1,
+      "platforms": [
+        6,
+        34,
+        48,
+        49,
+        130,
+        169
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -126605,6 +134190,10 @@
       ],
       "name": "Dreamo",
       "parent_game": -1,
+      "platforms": [
+        6,
+        130
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -126652,6 +134241,12 @@
       ],
       "name": "Mars Power Industries Deluxe",
       "parent_game": 108083,
+      "platforms": [
+        3,
+        6,
+        14,
+        49
+      ],
       "player_perspectives": [
         3
       ],
@@ -126702,6 +134297,15 @@
       "keywords": [],
       "name": "Control: The Foundation",
       "parent_game": 103329,
+      "platforms": [
+        6,
+        48,
+        49,
+        130,
+        167,
+        169,
+        170
+      ],
       "player_perspectives": [
         2
       ],
@@ -126757,6 +134361,15 @@
       "keywords": [],
       "name": "Control: AWE",
       "parent_game": 103329,
+      "platforms": [
+        6,
+        48,
+        49,
+        130,
+        167,
+        169,
+        170
+      ],
       "player_perspectives": [
         2
       ],
@@ -126817,6 +134430,12 @@
       ],
       "name": "Voxelgram",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        34,
+        130
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -126856,6 +134475,9 @@
       "keywords": [],
       "name": "Kabu Trader Shun",
       "parent_game": -1,
+      "platforms": [
+        20
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -126906,6 +134528,11 @@
       ],
       "name": "Midnight Protocol",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -126955,6 +134582,11 @@
       ],
       "name": "Murder by Numbers",
       "parent_game": -1,
+      "platforms": [
+        6,
+        130,
+        170
+      ],
       "player_perspectives": [
         2
       ],
@@ -127013,6 +134645,10 @@
       ],
       "name": "Wuppo: Definitive Edition",
       "parent_game": 26175,
+      "platforms": [
+        6,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -127064,6 +134700,11 @@
       ],
       "name": "Molek-Syntez",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         3
       ],
@@ -127116,6 +134757,12 @@
       "keywords": [],
       "name": "Borderlands 3: Moxxi's Heist of the Handsome Jackpot",
       "parent_game": 19164,
+      "platforms": [
+        6,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         1
       ],
@@ -127167,6 +134814,10 @@
       "keywords": [],
       "name": "Puppy Cross",
       "parent_game": -1,
+      "platforms": [
+        6,
+        130
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -127227,6 +134878,10 @@
       ],
       "name": "Piczle Cross Adventure",
       "parent_game": -1,
+      "platforms": [
+        6,
+        130
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -127277,6 +134932,9 @@
       ],
       "name": "Open World Game: The Open World Game",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [
         3
       ],
@@ -127325,6 +134983,12 @@
       "keywords": [],
       "name": "Borderlands 3: Guns, Love and Tentacles - The Marriage of Wainwright & Hammerlock",
       "parent_game": 19164,
+      "platforms": [
+        6,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         1
       ],
@@ -127379,6 +135043,9 @@
       ],
       "name": "Burn Me Twice",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [
         3
       ],
@@ -127429,6 +135096,13 @@
       "keywords": [],
       "name": "Saints Row: The Third Remastered",
       "parent_game": 873,
+      "platforms": [
+        6,
+        48,
+        49,
+        167,
+        169
+      ],
       "player_perspectives": [
         2
       ],
@@ -127484,6 +135158,13 @@
       ],
       "name": "Patrick's Parabox",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14,
+        130,
+        167
+      ],
       "player_perspectives": [
         3
       ],
@@ -127532,6 +135213,12 @@
       "keywords": [],
       "name": "Borderlands 3: Bounty of Blood - A Fistful of Redemption",
       "parent_game": 19164,
+      "platforms": [
+        6,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -127593,6 +135280,14 @@
       ],
       "name": "It Takes Two",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49,
+        130,
+        167,
+        169
+      ],
       "player_perspectives": [
         2
       ],
@@ -127641,6 +135336,9 @@
       ],
       "name": "Gemsweeper",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [
         3
       ],
@@ -127691,6 +135389,13 @@
       "keywords": [],
       "name": "The Outer Worlds: Peril on Gorgon",
       "parent_game": 113114,
+      "platforms": [
+        6,
+        48,
+        49,
+        130,
+        169
+      ],
       "player_perspectives": [
         1
       ],
@@ -127745,6 +135450,9 @@
       ],
       "name": "Black Mirror: Bandersnatch",
       "parent_game": -1,
+      "platforms": [
+        82
+      ],
       "player_perspectives": [
         5
       ],
@@ -127793,6 +135501,13 @@
       "keywords": [],
       "name": "The Outer Worlds: Murder on Eridanos",
       "parent_game": 113114,
+      "platforms": [
+        6,
+        48,
+        49,
+        130,
+        169
+      ],
       "player_perspectives": [
         1
       ],
@@ -127856,6 +135571,11 @@
       ],
       "name": "Suicide Squad: Kill the Justice League",
       "parent_game": -1,
+      "platforms": [
+        6,
+        167,
+        169
+      ],
       "player_perspectives": [
         2
       ],
@@ -127920,6 +135640,13 @@
       ],
       "name": "Gotham Knights",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49,
+        167,
+        169
+      ],
       "player_perspectives": [
         2
       ],
@@ -127975,6 +135702,12 @@
       ],
       "name": "Borderlands 3: Psycho Krieg and the Fantastic Fustercluck",
       "parent_game": 19164,
+      "platforms": [
+        6,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         1
       ],
@@ -128030,6 +135763,12 @@
       ],
       "name": "Batbarian: Testament of the Primordials",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -128081,6 +135820,12 @@
       "keywords": [],
       "name": "Mass Effect Legendary Edition",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49,
+        169
+      ],
       "player_perspectives": [
         2
       ],
@@ -128134,6 +135879,16 @@
       "keywords": [],
       "name": "Borderlands 3: Ultimate Edition",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14,
+        48,
+        49,
+        130,
+        167,
+        169,
+        170
+      ],
       "player_perspectives": [
         1
       ],
@@ -128203,6 +135958,11 @@
       ],
       "name": "Forza Horizon 5",
       "parent_game": -1,
+      "platforms": [
+        6,
+        49,
+        169
+      ],
       "player_perspectives": [
         1,
         2
@@ -128262,6 +136022,16 @@
       ],
       "name": "Disco Elysium: The Final Cut",
       "parent_game": 26472,
+      "platforms": [
+        6,
+        14,
+        48,
+        49,
+        130,
+        167,
+        169,
+        170
+      ],
       "player_perspectives": [
         3
       ],
@@ -128320,6 +136090,11 @@
       ],
       "name": "Nerts!: Online",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         3
       ],
@@ -128367,6 +136142,11 @@
       ],
       "name": "Copy Editor",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         5
       ],
@@ -128421,6 +136201,14 @@
       ],
       "name": "Oxenfree II: Lost Signals",
       "parent_game": -1,
+      "platforms": [
+        6,
+        34,
+        39,
+        48,
+        130,
+        167
+      ],
       "player_perspectives": [
         4
       ],
@@ -128481,6 +136269,11 @@
       ],
       "name": "The Great Ace Attorney Chronicles",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        130
+      ],
       "player_perspectives": [
         1,
         5
@@ -128564,6 +136357,14 @@
       ],
       "name": "The Great Ace Attorney 2: Resolve",
       "parent_game": -1,
+      "platforms": [
+        6,
+        34,
+        37,
+        39,
+        48,
+        130
+      ],
       "player_perspectives": [
         1,
         2,
@@ -128624,6 +136425,9 @@
       ],
       "name": "Khimera: Puzzle Island",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [
         4
       ],
@@ -128677,6 +136481,13 @@
       ],
       "name": "Outer Wilds: Echoes of the Eye",
       "parent_game": 11737,
+      "platforms": [
+        6,
+        48,
+        49,
+        130,
+        169
+      ],
       "player_perspectives": [
         1
       ],
@@ -128730,6 +136541,10 @@
       ],
       "name": "Tyrion Cuthbert: Attorney of the Arcane",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14
+      ],
       "player_perspectives": [],
       "ports": [],
       "release_dates": [
@@ -128786,6 +136601,13 @@
       ],
       "name": "Palworld",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14,
+        49,
+        167,
+        169
+      ],
       "player_perspectives": [
         2
       ],
@@ -128858,6 +136680,13 @@
       ],
       "name": "Tiny Tina's Wonderlands",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49,
+        167,
+        169
+      ],
       "player_perspectives": [
         1
       ],
@@ -128925,6 +136754,13 @@
       ],
       "name": "Marvel's Guardians of the Galaxy",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49,
+        167,
+        169
+      ],
       "player_perspectives": [
         2
       ],
@@ -128981,6 +136817,12 @@
       ],
       "name": "Castlevania Advance Collection",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -129040,6 +136882,11 @@
       ],
       "name": "Ghost of Tsushima: Director's Cut",
       "parent_game": 75235,
+      "platforms": [
+        6,
+        48,
+        167
+      ],
       "player_perspectives": [
         2
       ],
@@ -129103,6 +136950,9 @@
       ],
       "name": "The Legend of Zelda: Four Swords",
       "parent_game": -1,
+      "platforms": [
+        24
+      ],
       "player_perspectives": [
         3
       ],
@@ -129159,6 +137009,11 @@
       ],
       "name": "Middle-earth: Shadow of War - Blade of Galadriel",
       "parent_game": 27421,
+      "platforms": [
+        6,
+        48,
+        49
+      ],
       "player_perspectives": [
         2
       ],
@@ -129208,6 +137063,11 @@
       ],
       "name": "Middle-earth: Shadow of War - Desolation of Mordor",
       "parent_game": 27421,
+      "platforms": [
+        6,
+        48,
+        49
+      ],
       "player_perspectives": [
         1,
         2
@@ -129265,6 +137125,14 @@
       "name": "Saints Row",
       "name_glogAppendReleaseYear": true,
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49,
+        167,
+        169,
+        170
+      ],
       "player_perspectives": [
         2
       ],
@@ -129317,6 +137185,10 @@
       "keywords": [],
       "name": "Uncharted: Legacy of Thieves Collection",
       "parent_game": -1,
+      "platforms": [
+        6,
+        167
+      ],
       "player_perspectives": [
         2
       ],
@@ -129363,6 +137235,7 @@
       ],
       "name": "Wonder Woman",
       "parent_game": -1,
+      "platforms": [],
       "player_perspectives": [
         2
       ],
@@ -129403,6 +137276,9 @@
       "keywords": [],
       "name": "Depict1",
       "parent_game": -1,
+      "platforms": [
+        82
+      ],
       "player_perspectives": [
         4
       ],
@@ -129456,6 +137332,13 @@
       ],
       "name": "Star Wars Jedi: Survivor",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49,
+        167,
+        169
+      ],
       "player_perspectives": [
         2
       ],
@@ -129535,6 +137418,13 @@
       ],
       "name": "Dave the Diver",
       "parent_game": -1,
+      "platforms": [
+        6,
+        14,
+        48,
+        130,
+        167
+      ],
       "player_perspectives": [
         4
       ],
@@ -129596,6 +137486,10 @@
       ],
       "name": "The Last of Us Part I",
       "parent_game": 1009,
+      "platforms": [
+        6,
+        167
+      ],
       "player_perspectives": [
         2
       ],
@@ -129647,6 +137541,9 @@
       ],
       "name": "Stormgate",
       "parent_game": -1,
+      "platforms": [
+        6
+      ],
       "player_perspectives": [
         3
       ],
@@ -129702,6 +137599,11 @@
       ],
       "name": "Last Call BBS",
       "parent_game": -1,
+      "platforms": [
+        3,
+        6,
+        14
+      ],
       "player_perspectives": [
         3
       ],
@@ -129751,6 +137653,12 @@
       "keywords": [],
       "name": "Shadow of Destiny",
       "parent_game": -1,
+      "platforms": [
+        6,
+        8,
+        11,
+        38
+      ],
       "player_perspectives": [
         2
       ],
@@ -129811,6 +137719,11 @@
       ],
       "name": "Cyberpunk 2077: Phantom Liberty",
       "parent_game": 1877,
+      "platforms": [
+        6,
+        167,
+        169
+      ],
       "player_perspectives": [
         1,
         2
@@ -129866,6 +137779,9 @@
       "keywords": [],
       "name": "Horizon Forbidden West: Burning Shores",
       "parent_game": 112874,
+      "platforms": [
+        167
+      ],
       "player_perspectives": [
         2
       ],
@@ -129921,6 +137837,9 @@
       ],
       "name": "Metroid Prime Remastered",
       "parent_game": 1105,
+      "platforms": [
+        130
+      ],
       "player_perspectives": [
         1
       ],
@@ -129966,6 +137885,13 @@
       "keywords": [],
       "name": "Saints Row: The Heist & The Hazardous",
       "parent_game": 165346,
+      "platforms": [
+        6,
+        48,
+        49,
+        167,
+        169
+      ],
       "player_perspectives": [
         2
       ],
@@ -130026,6 +137952,14 @@
       ],
       "name": "Cat Quest III",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49,
+        130,
+        167,
+        169
+      ],
       "player_perspectives": [
         3
       ],
@@ -130084,6 +138018,11 @@
       ],
       "name": "Star Wars Outlaws",
       "parent_game": -1,
+      "platforms": [
+        6,
+        167,
+        169
+      ],
       "player_perspectives": [
         2
       ],
@@ -130139,6 +138078,12 @@
       "keywords": [],
       "name": "Apollo Justice: Ace Attorney Trilogy",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         2,
         4,
@@ -130194,6 +138139,9 @@
       "name": "Super Mario RPG",
       "name_glogAppendReleaseYear": true,
       "parent_game": 5418,
+      "platforms": [
+        130
+      ],
       "player_perspectives": [
         3
       ],
@@ -130261,6 +138209,9 @@
       ],
       "name": "Super Mario Bros. Wonder",
       "parent_game": -1,
+      "platforms": [
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -130306,6 +138257,13 @@
       "keywords": [],
       "name": "Saints Row: Doc Ketchum's Murder Circus",
       "parent_game": 165346,
+      "platforms": [
+        6,
+        48,
+        49,
+        167,
+        169
+      ],
       "player_perspectives": [
         2
       ],
@@ -130356,6 +138314,13 @@
       "keywords": [],
       "name": "Saints Row: A Song of Ice & Dust",
       "parent_game": 165346,
+      "platforms": [
+        6,
+        48,
+        49,
+        167,
+        169
+      ],
       "player_perspectives": [
         2
       ],
@@ -130411,6 +138376,9 @@
       "name": "Paper Mario: The Thousand-Year Door",
       "name_glogAppendReleaseYear": true,
       "parent_game": 3349,
+      "platforms": [
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -130458,6 +138426,15 @@
       "keywords": [],
       "name": "Borderlands 3: Director's Cut",
       "parent_game": 19164,
+      "platforms": [
+        6,
+        48,
+        49,
+        130,
+        167,
+        169,
+        170
+      ],
       "player_perspectives": [
         1,
         2
@@ -130519,6 +138496,11 @@
       "keywords": [],
       "name": "LEGO Horizon Adventures",
       "parent_game": -1,
+      "platforms": [
+        6,
+        130,
+        167
+      ],
       "player_perspectives": [
         3
       ],
@@ -130576,6 +138558,11 @@
       ],
       "name": "The Talos Principle II: Road to Elysium",
       "parent_game": 79864,
+      "platforms": [
+        6,
+        167,
+        169
+      ],
       "player_perspectives": [
         1,
         2
@@ -130630,6 +138617,9 @@
       ],
       "name": "The Legend of Zelda: Echoes of Wisdom",
       "parent_game": -1,
+      "platforms": [
+        130
+      ],
       "player_perspectives": [
         3
       ],
@@ -130679,6 +138669,12 @@
       "keywords": [],
       "name": "Ace Attorney Investigations Collection",
       "parent_game": -1,
+      "platforms": [
+        6,
+        48,
+        49,
+        130
+      ],
       "player_perspectives": [
         4
       ],
@@ -130725,6 +138721,10 @@
       "keywords": [],
       "name": "Voxelgram: DLC #1",
       "parent_game": 122807,
+      "platforms": [
+        3,
+        6
+      ],
       "player_perspectives": [
         3
       ],
@@ -130772,6 +138772,12 @@
       "keywords": [],
       "name": "Castlevania Dominus Collection",
       "parent_game": -1,
+      "platforms": [
+        6,
+        130,
+        167,
+        169
+      ],
       "player_perspectives": [
         4
       ],
@@ -130815,6 +138821,9 @@
       "keywords": [],
       "name": "Ghost of Yotei",
       "parent_game": -1,
+      "platforms": [
+        167
+      ],
       "player_perspectives": [
         2
       ],
@@ -132960,22 +140969,6 @@
     {
       "id": 11991,
       "company": 1366
-    },
-    {
-      "id": 12074,
-      "company": 1474
-    },
-    {
-      "id": 12075,
-      "company": 451
-    },
-    {
-      "id": 12076,
-      "company": 2230
-    },
-    {
-      "id": 12077,
-      "company": 2231
     },
     {
       "id": 12617,
@@ -145618,6 +153611,26 @@
       "company": 9786
     },
     {
+      "id": 290288,
+      "company": 2231
+    },
+    {
+      "id": 290289,
+      "company": 2230
+    },
+    {
+      "id": 290290,
+      "company": 451
+    },
+    {
+      "id": 290291,
+      "company": 1474
+    },
+    {
+      "id": 290292,
+      "company": 2582
+    },
+    {
       "id": 291129,
       "company": 7871
     },
@@ -145633,118 +153646,330 @@
       "id": -1
     },
     {
+      "abbreviation": "Linux",
+      "alternative_name": "GNU/Linux",
+      "id": 3,
+      "name": "Linux",
+      "url": "https://www.igdb.com/platforms/linux"
+    },
+    {
       "abbreviation": "N64",
+      "alternative_name": "N64",
       "id": 4,
       "name": "Nintendo 64",
       "url": "https://www.igdb.com/platforms/n64"
     },
     {
       "abbreviation": "Wii",
+      "alternative_name": "Revolution",
       "id": 5,
       "name": "Wii",
       "url": "https://www.igdb.com/platforms/wii"
     },
     {
       "abbreviation": "PC",
+      "alternative_name": "mswin",
       "id": 6,
       "name": "PC (Microsoft Windows)",
       "url": "https://www.igdb.com/platforms/win"
     },
     {
       "abbreviation": "PS1",
+      "alternative_name": "PSX, PSOne, PS",
       "id": 7,
       "name": "PlayStation",
       "url": "https://www.igdb.com/platforms/ps"
     },
     {
       "abbreviation": "PS2",
+      "alternative_name": "PS2",
       "id": 8,
       "name": "PlayStation 2",
       "url": "https://www.igdb.com/platforms/ps2"
     },
     {
       "abbreviation": "PS3",
+      "alternative_name": "PS3",
       "id": 9,
       "name": "PlayStation 3",
       "url": "https://www.igdb.com/platforms/ps3"
     },
     {
+      "abbreviation": "XBOX",
+      "id": 11,
+      "name": "Xbox",
+      "url": "https://www.igdb.com/platforms/xbox"
+    },
+    {
       "abbreviation": "X360",
+      "alternative_name": "X360",
       "id": 12,
       "name": "Xbox 360",
       "url": "https://www.igdb.com/platforms/xbox360"
     },
     {
+      "abbreviation": "DOS",
+      "alternative_name": "PC DOS",
+      "id": 13,
+      "name": "DOS",
+      "url": "https://www.igdb.com/platforms/dos"
+    },
+    {
       "abbreviation": "Mac",
+      "alternative_name": "Mac OS",
       "id": 14,
       "name": "Mac",
       "url": "https://www.igdb.com/platforms/mac"
     },
     {
+      "abbreviation": "C64",
+      "alternative_name": "C64/C128/MAX",
+      "id": 15,
+      "name": "Commodore C64/128/MAX",
+      "url": "https://www.igdb.com/platforms/c64"
+    },
+    {
+      "abbreviation": "Amiga",
+      "alternative_name": "Commodore Amiga",
+      "id": 16,
+      "name": "Amiga",
+      "url": "https://www.igdb.com/platforms/amiga"
+    },
+    {
       "abbreviation": "NES",
+      "alternative_name": "NES",
       "id": 18,
       "name": "Nintendo Entertainment System",
       "url": "https://www.igdb.com/platforms/nes"
     },
     {
       "abbreviation": "SNES",
+      "alternative_name": "SNES, Super Nintendo",
       "id": 19,
       "name": "Super Nintendo Entertainment System",
       "url": "https://www.igdb.com/platforms/snes"
     },
     {
       "abbreviation": "NDS",
+      "alternative_name": "NDS",
       "id": 20,
       "name": "Nintendo DS",
       "url": "https://www.igdb.com/platforms/nds"
     },
     {
       "abbreviation": "NGC",
+      "alternative_name": "GCN",
       "id": 21,
       "name": "Nintendo GameCube",
       "url": "https://www.igdb.com/platforms/ngc"
     },
     {
+      "abbreviation": "DC",
+      "alternative_name": "DC",
+      "id": 23,
+      "name": "Dreamcast",
+      "url": "https://www.igdb.com/platforms/dc"
+    },
+    {
       "abbreviation": "GBA",
+      "alternative_name": "GBA",
       "id": 24,
       "name": "Game Boy Advance",
       "url": "https://www.igdb.com/platforms/gba"
     },
     {
+      "abbreviation": "ACPC",
+      "alternative_name": "Colour Personal Computer",
+      "id": 25,
+      "name": "Amstrad CPC",
+      "url": "https://www.igdb.com/platforms/acpc"
+    },
+    {
+      "abbreviation": "ZXS",
+      "id": 26,
+      "name": "ZX Spectrum",
+      "url": "https://www.igdb.com/platforms/zxs"
+    },
+    {
+      "abbreviation": "MSX",
+      "id": 27,
+      "name": "MSX",
+      "url": "https://www.igdb.com/platforms/msx"
+    },
+    {
+      "abbreviation": "Genesis/MegaDrive",
+      "alternative_name": "Sega Genesis",
+      "id": 29,
+      "name": "Sega Mega Drive/Genesis",
+      "url": "https://www.igdb.com/platforms/genesis-slash-megadrive"
+    },
+    {
+      "abbreviation": "Saturn",
+      "alternative_name": "JVC Saturn, Hi-Saturn, Samsung Saturn, V-Saturn",
+      "id": 32,
+      "name": "Sega Saturn",
+      "url": "https://www.igdb.com/platforms/saturn"
+    },
+    {
+      "abbreviation": "Game Boy",
+      "alternative_name": "GB",
+      "id": 33,
+      "name": "Game Boy",
+      "url": "https://www.igdb.com/platforms/gb"
+    },
+    {
       "abbreviation": "Android",
+      "alternative_name": "Infocusa3",
       "id": 34,
       "name": "Android",
       "url": "https://www.igdb.com/platforms/android"
     },
     {
       "abbreviation": "3DS",
+      "alternative_name": "3DS",
       "id": 37,
       "name": "Nintendo 3DS",
       "url": "https://www.igdb.com/platforms/3ds"
     },
     {
+      "abbreviation": "PSP",
+      "alternative_name": "PSP",
+      "id": 38,
+      "name": "PlayStation Portable",
+      "url": "https://www.igdb.com/platforms/psp"
+    },
+    {
+      "abbreviation": "iOS",
+      "id": 39,
+      "name": "iOS",
+      "url": "https://www.igdb.com/platforms/ios"
+    },
+    {
       "abbreviation": "WiiU",
+      "alternative_name": "Project Cafe",
       "id": 41,
       "name": "Wii U",
       "url": "https://www.igdb.com/platforms/wiiu"
     },
     {
+      "abbreviation": "NGage",
+      "alternative_name": "NGage",
+      "id": 42,
+      "name": "N-Gage",
+      "url": "https://www.igdb.com/platforms/ngage"
+    },
+    {
       "abbreviation": "Vita",
+      "alternative_name": "PS Vita",
       "id": 46,
       "name": "PlayStation Vita",
       "url": "https://www.igdb.com/platforms/psvita"
     },
     {
       "abbreviation": "PS4",
+      "alternative_name": "PS4",
       "id": 48,
       "name": "PlayStation 4",
       "url": "https://www.igdb.com/platforms/ps4--1"
     },
     {
       "abbreviation": "XONE",
+      "alternative_name": "XONE",
       "id": 49,
       "name": "Xbox One",
       "url": "https://www.igdb.com/platforms/xboxone"
+    },
+    {
+      "abbreviation": "3DO",
+      "alternative_name": "3DO",
+      "id": 50,
+      "name": "3DO Interactive Multiplayer",
+      "url": "https://www.igdb.com/platforms/3do"
+    },
+    {
+      "abbreviation": "fds",
+      "alternative_name": "Famicom Disk System, FDS",
+      "id": 51,
+      "name": "Family Computer Disk System",
+      "url": "https://www.igdb.com/platforms/fds"
+    },
+    {
+      "abbreviation": "Arcade",
+      "id": 52,
+      "name": "Arcade",
+      "url": "https://www.igdb.com/platforms/arcade"
+    },
+    {
+      "abbreviation": "MSX2",
+      "id": 53,
+      "name": "MSX2",
+      "url": "https://www.igdb.com/platforms/msx2"
+    },
+    {
+      "abbreviation": "Mobile",
+      "alternative_name": "Legacy Cellphone",
+      "id": 55,
+      "name": "Legacy Mobile Device",
+      "url": "https://www.igdb.com/platforms/mobile"
+    },
+    {
+      "abbreviation": "SFAM",
+      "alternative_name": "SFC",
+      "id": 58,
+      "name": "Super Famicom",
+      "url": "https://www.igdb.com/platforms/sfam"
+    },
+    {
+      "abbreviation": "Atari7800",
+      "alternative_name": "Atari 7800 ProSystem",
+      "id": 60,
+      "name": "Atari 7800",
+      "url": "https://www.igdb.com/platforms/atari7800"
+    },
+    {
+      "abbreviation": "Lynx",
+      "id": 61,
+      "name": "Atari Lynx",
+      "url": "https://www.igdb.com/platforms/lynx"
+    },
+    {
+      "abbreviation": "Atari-ST",
+      "id": 63,
+      "name": "Atari ST/STE",
+      "url": "https://www.igdb.com/platforms/atari-st"
+    },
+    {
+      "abbreviation": "SMS",
+      "alternative_name": "SMS, Mark III",
+      "id": 64,
+      "name": "Sega Master System/Mark III",
+      "url": "https://www.igdb.com/platforms/sms"
+    },
+    {
+      "abbreviation": "Atari8bit",
+      "id": 65,
+      "name": "Atari 8-bit",
+      "url": "https://www.igdb.com/platforms/atari8bit"
+    },
+    {
+      "abbreviation": "Atari5200",
+      "alternative_name": "Atari 5200 SuperSystem",
+      "id": 66,
+      "name": "Atari 5200",
+      "url": "https://www.igdb.com/platforms/atari5200"
+    },
+    {
+      "abbreviation": "bbcmicro",
+      "alternative_name": "BBC Micro",
+      "id": 69,
+      "name": "BBC Microcomputer System",
+      "url": "https://www.igdb.com/platforms/bbcmicro"
+    },
+    {
+      "abbreviation": "vic-20",
+      "id": 71,
+      "name": "Commodore VIC-20",
+      "url": "https://www.igdb.com/platforms/vic-20"
     },
     {
       "abbreviation": "Ouya",
@@ -145753,16 +153978,300 @@
       "url": "https://www.igdb.com/platforms/ouya"
     },
     {
+      "abbreviation": "blackberry",
+      "id": 73,
+      "name": "BlackBerry OS",
+      "url": "https://www.igdb.com/platforms/blackberry"
+    },
+    {
+      "abbreviation": "Win Phone",
+      "alternative_name": "WP",
+      "id": 74,
+      "name": "Windows Phone",
+      "url": "https://www.igdb.com/platforms/winphone"
+    },
+    {
+      "abbreviation": "Apple][",
+      "alternative_name": "apple ][",
+      "id": 75,
+      "name": "Apple II",
+      "url": "https://www.igdb.com/platforms/appleii"
+    },
+    {
+      "abbreviation": "x1",
+      "id": 77,
+      "name": "Sharp X1",
+      "url": "https://www.igdb.com/platforms/x1"
+    },
+    {
+      "abbreviation": "segacd",
+      "alternative_name": "Mega CD",
+      "id": 78,
+      "name": "Sega CD",
+      "url": "https://www.igdb.com/platforms/segacd"
+    },
+    {
+      "abbreviation": "neogeomvs",
+      "alternative_name": "Neo Geo Multi Video System",
+      "id": 79,
+      "name": "Neo Geo MVS",
+      "url": "https://www.igdb.com/platforms/neogeomvs"
+    },
+    {
+      "abbreviation": "neogeoaes",
+      "alternative_name": "AES",
+      "id": 80,
+      "name": "Neo Geo AES",
+      "url": "https://www.igdb.com/platforms/neogeoaes"
+    },
+    {
+      "abbreviation": "browser",
+      "alternative_name": "Internet",
+      "id": 82,
+      "name": "Web browser",
+      "url": "https://www.igdb.com/platforms/browser"
+    },
+    {
+      "abbreviation": "turbografx16",
+      "alternative_name": "TG16",
+      "id": 86,
+      "name": "TurboGrafx-16/PC Engine",
+      "url": "https://www.igdb.com/platforms/turbografx16--1"
+    },
+    {
+      "abbreviation": "famicom",
+      "alternative_name": "Famicom",
+      "id": 99,
+      "name": "Family Computer",
+      "url": "https://www.igdb.com/platforms/famicom"
+    },
+    {
+      "abbreviation": "hp2100",
+      "id": 104,
+      "name": "HP 2100",
+      "url": "https://www.igdb.com/platforms/hp2100"
+    },
+    {
+      "abbreviation": "cdccyber70",
+      "id": 109,
+      "name": "CDC Cyber 70",
+      "url": "https://www.igdb.com/platforms/cdccyber70"
+    },
+    {
+      "id": 113,
+      "name": "OnLive Game System",
+      "url": "https://www.igdb.com/platforms/onlive-game-system"
+    },
+    {
+      "id": 114,
+      "name": "Amiga CD32",
+      "url": "https://www.igdb.com/platforms/amiga-cd32"
+    },
+    {
+      "id": 115,
+      "name": "Apple IIGS",
+      "url": "https://www.igdb.com/platforms/apple-iigs"
+    },
+    {
+      "id": 116,
+      "name": "Acorn Archimedes",
+      "url": "https://www.igdb.com/platforms/acorn-archimedes"
+    },
+    {
+      "id": 117,
+      "name": "Philips CD-i",
+      "url": "https://www.igdb.com/platforms/philips-cd-i"
+    },
+    {
+      "id": 118,
+      "name": "FM Towns",
+      "url": "https://www.igdb.com/platforms/fm-towns"
+    },
+    {
+      "id": 121,
+      "name": "Sharp X68000",
+      "url": "https://www.igdb.com/platforms/sharp-x68000"
+    },
+    {
+      "alternative_name": "WSC",
+      "id": 123,
+      "name": "WonderSwan Color",
+      "url": "https://www.igdb.com/platforms/wonderswan-color"
+    },
+    {
       "abbreviation": "Switch",
+      "alternative_name": "NX",
       "id": 130,
       "name": "Nintendo Switch",
       "url": "https://www.igdb.com/platforms/switch"
     },
     {
+      "alternative_name": "SNES-CD",
+      "id": 131,
+      "name": "Super NES CD-ROM System",
+      "url": "https://www.igdb.com/platforms/super-nes-cd-rom-system"
+    },
+    {
+      "id": 132,
+      "name": "Amazon Fire TV",
+      "url": "https://www.igdb.com/platforms/amazon-fire-tv"
+    },
+    {
+      "id": 134,
+      "name": "Acorn Electron",
+      "url": "https://www.igdb.com/platforms/acorn-electron"
+    },
+    {
+      "alternative_name": "NGCD",
+      "id": 136,
+      "name": "Neo Geo CD",
+      "url": "https://www.igdb.com/platforms/neo-geo-cd"
+    },
+    {
+      "alternative_name": "n3DS",
+      "id": 137,
+      "name": "New Nintendo 3DS",
+      "url": "https://www.igdb.com/platforms/new-nintendo-3ds"
+    },
+    {
+      "alternative_name": "PC-98",
+      "id": 149,
+      "name": "PC-9800 Series",
+      "url": "https://www.igdb.com/platforms/pc-9800-series"
+    },
+    {
+      "alternative_name": "Commodore Dynamic Total Vision",
+      "id": 158,
+      "name": "Commodore CDTV",
+      "url": "https://www.igdb.com/platforms/commodore-cdtv"
+    },
+    {
+      "id": 159,
+      "name": "Nintendo DSi",
+      "url": "https://www.igdb.com/platforms/nintendo-dsi"
+    },
+    {
+      "alternative_name": "WMR",
+      "id": 161,
+      "name": "Windows Mixed Reality",
+      "url": "https://www.igdb.com/platforms/windows-mixed-reality"
+    },
+    {
+      "abbreviation": "Oculus VR",
+      "id": 162,
+      "name": "Oculus VR",
+      "url": "https://www.igdb.com/platforms/oculus-vr"
+    },
+    {
+      "abbreviation": "Steam VR",
+      "id": 163,
+      "name": "SteamVR",
+      "url": "https://www.igdb.com/platforms/steam-vr"
+    },
+    {
+      "abbreviation": "PSVR",
+      "alternative_name": "PSVR",
+      "id": 165,
+      "name": "PlayStation VR",
+      "url": "https://www.igdb.com/platforms/psvr"
+    },
+    {
       "abbreviation": "PS5",
+      "alternative_name": "PS5",
       "id": 167,
       "name": "PlayStation 5",
       "url": "https://www.igdb.com/platforms/ps5"
+    },
+    {
+      "abbreviation": "Series X|S",
+      "alternative_name": "XSX",
+      "id": 169,
+      "name": "Xbox Series X|S",
+      "url": "https://www.igdb.com/platforms/series-x-s"
+    },
+    {
+      "abbreviation": "Stadia",
+      "alternative_name": "Stadia",
+      "id": 170,
+      "name": "Google Stadia",
+      "url": "https://www.igdb.com/platforms/stadia"
+    },
+    {
+      "id": 306,
+      "name": "Satellaview",
+      "url": "https://www.igdb.com/platforms/satellaview"
+    },
+    {
+      "alternative_name": "TV Game",
+      "id": 377,
+      "name": "Plug & Play",
+      "url": "https://www.igdb.com/platforms/plug-and-play"
+    },
+    {
+      "alternative_name": "Quest",
+      "id": 384,
+      "name": "Oculus Quest",
+      "url": "https://www.igdb.com/platforms/oculus-quest"
+    },
+    {
+      "alternative_name": "Rift",
+      "id": 385,
+      "name": "Oculus Rift",
+      "url": "https://www.igdb.com/platforms/oculus-rift"
+    },
+    {
+      "abbreviation": "Meta Quest 2",
+      "alternative_name": "Quest 2",
+      "id": 386,
+      "name": "Meta Quest 2",
+      "url": "https://www.igdb.com/platforms/meta-quest-2"
+    },
+    {
+      "abbreviation": "PSVR2",
+      "alternative_name": "PSVR2",
+      "id": 390,
+      "name": "PlayStation VR2",
+      "url": "https://www.igdb.com/platforms/psvr2"
+    },
+    {
+      "alternative_name": "Pocket PC",
+      "id": 405,
+      "name": "Windows Mobile",
+      "url": "https://www.igdb.com/platforms/windows-mobile"
+    },
+    {
+      "alternative_name": "Jag CD",
+      "id": 410,
+      "name": "Atari Jaguar CD",
+      "url": "https://www.igdb.com/platforms/atari-jaguar-cd"
+    },
+    {
+      "alternative_name": "Nintendo 64DD",
+      "id": 416,
+      "name": "64DD",
+      "url": "https://www.igdb.com/platforms/64dd"
+    },
+    {
+      "alternative_name": "Garnet OS",
+      "id": 417,
+      "name": "Palm OS",
+      "url": "https://www.igdb.com/platforms/palm-os"
+    },
+    {
+      "id": 472,
+      "name": "visionOS",
+      "url": "https://www.igdb.com/platforms/visionos"
+    },
+    {
+      "alternative_name": "Gametraq",
+      "id": 474,
+      "name": "Gizmondo",
+      "url": "https://www.igdb.com/platforms/gizmondo"
+    },
+    {
+      "id": 487,
+      "name": "LaserActive",
+      "url": "https://www.igdb.com/platforms/laseractive"
     }
   ],
   "playerPerspectives": [


### PR DESCRIPTION
For example, "Ghostbusters: The Video Game (PC, PS3, X360)" is now distinct from "Ghostbusters: The Video Game (PS2, PSP, Wii)"

Includes necessary `GetReferenceString()` and nearby refactoring so that generating a game's displayable + referenceable string can look up platform names in the cache.