### PR TITLE
Prevent `PostIdFromFilePath` parsing from adding unwanted DataReferences during a data update.

### DIFF
--- a/GlogGenerator/Data/PageData.cs
+++ b/GlogGenerator/Data/PageData.cs
@@ -36,9 +36,12 @@ namespace GlogGenerator.Data
 
         public static string PageIdFromFilePath(MarkdownPipeline mdPipeline, string filePath)
         {
+            // Disable the data index in this file parse, so that it doesn't create unwanted data references.
+            var parseContext = MarkdownParserContextExtensions.DontUseSiteDataIndex();
+
             // We need to parse the file to determine its permalink, based on front matter data.
             var fileContent = File.ReadAllText(filePath);
-            var mdDoc = Markdown.Parse(fileContent, mdPipeline);
+            var mdDoc = Markdown.Parse(fileContent, mdPipeline, parseContext);
 
             string permalinkRelative = null;
             var frontMatterBlock = mdDoc.Descendants<TomlFrontMatterBlock>().FirstOrDefault();

--- a/GlogGenerator/Data/PostData.cs
+++ b/GlogGenerator/Data/PostData.cs
@@ -106,9 +106,12 @@ namespace GlogGenerator.Data
 
         public static string PostIdFromFilePath(MarkdownPipeline mdPipeline, string filePath)
         {
+            // Disable the data index in this file parse, so that it doesn't create unwanted data references.
+            var parseContext = MarkdownParserContextExtensions.DontUseSiteDataIndex();
+
             // We need to parse the file to determine its permalink, based on front matter data.
             var fileContent = File.ReadAllText(filePath);
-            var mdDoc = Markdown.Parse(fileContent, mdPipeline);
+            var mdDoc = Markdown.Parse(fileContent, mdPipeline, parseContext);
 
             DateTimeOffset postDate = DateTimeOffset.MinValue;
             string postSlug = null;

--- a/GlogGenerator/MarkdownExtensions/GlogAutoLinkInlineParser.cs
+++ b/GlogGenerator/MarkdownExtensions/GlogAutoLinkInlineParser.cs
@@ -73,7 +73,8 @@ namespace GlogGenerator.MarkdownExtensions
                         var referenceTypeName = linkMatchHandler.Value;
                         var referenceKey = slice.Text.Substring(slice.Start, referenceEndPos - slice.Start);
 
-                        var glogLinkInline = new GlogLinkInline(referenceTypeName, referenceKey, this.siteDataIndex)
+                        var linkDataIndex = processor.Context.UseSiteDataIndex() ? this.siteDataIndex : null;
+                        var glogLinkInline = new GlogLinkInline(referenceTypeName, referenceKey, linkDataIndex)
                         {
                             IsAutoLink = true,
                             // TODO?: would filling in Span, Row, and Column accomplish anything?

--- a/GlogGenerator/MarkdownExtensions/GlogLinkInline.cs
+++ b/GlogGenerator/MarkdownExtensions/GlogLinkInline.cs
@@ -8,65 +8,80 @@ namespace GlogGenerator.MarkdownExtensions
     {
         public string ReferenceTypeName { get; private set; }
 
-        public ISiteDataReference DataReference { get; private set; }
+        private readonly string originalReferenceKey;
+        private readonly ISiteDataReference dataReference;
 
         public GlogLinkInline(string referenceTypeName, string referenceKey, ISiteDataIndex siteDataIndex)
         {
             this.ReferenceTypeName = referenceTypeName;
-            switch (referenceTypeName)
+            this.originalReferenceKey = referenceKey;
+
+            if (siteDataIndex == null)
             {
-                case "category":
-                    this.DataReference = siteDataIndex.CreateReference<CategoryData>(referenceKey) as ISiteDataReference;
-                    break;
+                this.dataReference = null;
+            }
+            else
+            {
+                switch (referenceTypeName)
+                {
+                    case "category":
+                        this.dataReference = siteDataIndex.CreateReference<CategoryData>(referenceKey) as ISiteDataReference;
+                        break;
 
-                case "game":
-                    this.DataReference = siteDataIndex.CreateReference<GameData>(referenceKey) as ISiteDataReference;
-                    break;
+                    case "game":
+                        this.dataReference = siteDataIndex.CreateReference<GameData>(referenceKey) as ISiteDataReference;
+                        break;
 
-                case "platform":
-                    this.DataReference = siteDataIndex.CreateReference<PlatformData>(referenceKey) as ISiteDataReference;
-                    break;
+                    case "platform":
+                        this.dataReference = siteDataIndex.CreateReference<PlatformData>(referenceKey) as ISiteDataReference;
+                        break;
 
-                case "rating":
-                    this.DataReference = siteDataIndex.CreateReference<RatingData>(referenceKey) as ISiteDataReference;
-                    break;
+                    case "rating":
+                        this.dataReference = siteDataIndex.CreateReference<RatingData>(referenceKey) as ISiteDataReference;
+                        break;
 
-                case "tag":
-                    this.DataReference = siteDataIndex.CreateReference<TagData>(referenceKey) as ISiteDataReference;
-                    break;
+                    case "tag":
+                        this.dataReference = siteDataIndex.CreateReference<TagData>(referenceKey) as ISiteDataReference;
+                        break;
 
-                default:
-                    throw new NotImplementedException();
+                    default:
+                        throw new NotImplementedException();
+                }
             }
         }
 
         public string GetReferenceKey(ISiteDataIndex siteDataIndex)
         {
+            if (this.dataReference == null)
+            {
+                return this.originalReferenceKey;
+            }
+
             IGlogReferenceable data;
             switch (this.ReferenceTypeName)
             {
                 case "category":
-                    var categoryReference = this.DataReference as SiteDataReference<CategoryData>;
+                    var categoryReference = this.dataReference as SiteDataReference<CategoryData>;
                     data = siteDataIndex.GetData<CategoryData>(categoryReference);
                     break;
 
                 case "game":
-                    var gameReference = this.DataReference as SiteDataReference<GameData>;
+                    var gameReference = this.dataReference as SiteDataReference<GameData>;
                     data = siteDataIndex.GetData<GameData>(gameReference);
                     break;
 
                 case "platform":
-                    var platformReference = this.DataReference as SiteDataReference<PlatformData>;
+                    var platformReference = this.dataReference as SiteDataReference<PlatformData>;
                     data = siteDataIndex.GetData<PlatformData>(platformReference);
                     break;
 
                 case "rating":
-                    var ratingReference = this.DataReference as SiteDataReference<RatingData>;
+                    var ratingReference = this.dataReference as SiteDataReference<RatingData>;
                     data = siteDataIndex.GetData<RatingData>(ratingReference);
                     break;
 
                 case "tag":
-                    var tagReference = this.DataReference as SiteDataReference<TagData>;
+                    var tagReference = this.dataReference as SiteDataReference<TagData>;
                     data = siteDataIndex.GetData<TagData>(tagReference);
                     break;
 
@@ -76,7 +91,7 @@ namespace GlogGenerator.MarkdownExtensions
 
             if (data == null)
             {
-                throw new ArgumentException($"No {this.ReferenceTypeName} found with key {this.DataReference.GetUnresolvedReferenceKey()}");
+                throw new ArgumentException($"No {this.ReferenceTypeName} found with key {this.dataReference.GetUnresolvedReferenceKey()}");
             }
 
             return data.GetReferenceableKey();

--- a/GlogGenerator/MarkdownExtensions/GlogLinkInlineParser.cs
+++ b/GlogGenerator/MarkdownExtensions/GlogLinkInlineParser.cs
@@ -76,7 +76,8 @@ namespace GlogGenerator.MarkdownExtensions
                         var referenceTypeName = linkMatchHandler.Value;
                         var referenceKey = slice.Text.Substring(slice.Start, referenceEndPos - slice.Start);
 
-                        var glogLinkInline = new GlogLinkInline(referenceTypeName, referenceKey, this.siteDataIndex)
+                        var linkDataIndex = processor.Context.UseSiteDataIndex() ? this.siteDataIndex : null;
+                        var glogLinkInline = new GlogLinkInline(referenceTypeName, referenceKey, linkDataIndex)
                         {
                             // TODO?: would filling in Span, Row, and Column accomplish anything?
                         };

--- a/GlogGenerator/MarkdownExtensions/MarkdownParserContextExtensions.cs
+++ b/GlogGenerator/MarkdownExtensions/MarkdownParserContextExtensions.cs
@@ -1,0 +1,31 @@
+using Markdig;
+
+namespace GlogGenerator.MarkdownExtensions
+{
+    public static class MarkdownParserContextExtensions
+    {
+        const string useSiteDataIndexPropertyName = "glog_useSiteDataIndex";
+
+        public static bool UseSiteDataIndex(this MarkdownParserContext context)
+        {
+            if (context == null)
+            {
+                return true;
+            }
+
+            if (context.Properties.TryGetValue(useSiteDataIndexPropertyName, out var useSiteDataIndexProperty))
+            {
+                return (bool)useSiteDataIndexProperty;
+            }
+
+            return true;
+        }
+
+        public static MarkdownParserContext DontUseSiteDataIndex()
+        {
+            var context = new MarkdownParserContext();
+            context.Properties[useSiteDataIndexPropertyName] = false;
+            return context;
+        }
+    }
+}


### PR DESCRIPTION
Found while processing big IGDB cache updates (collecting related games): depending upon order of operations, `PostIdFromFilePath`'s Markdown.Parse had a possibility of re-introducing "old" content's reference keys to the SiteDataIndex even while the index was preparing to rewrite "new" content with a modified reference key.

In other worse, the `PostIdFromFilePath` parse needs to avoid (re-)introducing data references to the site index.