### PR TITLE
DataReferences sometimes *don't* update

### DIFF
--- a/GlogGenerator.Test/Data/FakeSiteDataIndex.cs
+++ b/GlogGenerator.Test/Data/FakeSiteDataIndex.cs
@@ -14,10 +14,10 @@ namespace GlogGenerator.Test
         private List<RatingData> ratings = new List<RatingData>();
         private List<TagData> tags = new List<TagData>();
 
-        public SiteDataReference<T> CreateReference<T>(string referenceKey)
+        public SiteDataReference<T> CreateReference<T>(string referenceKey, bool shouldUpdateOnDataChange)
             where T : IGlogReferenceable
         {
-            return new SiteDataReference<T>(referenceKey);
+            return new SiteDataReference<T>(referenceKey, shouldUpdateOnDataChange);
         }
 
         public T GetData<T>(SiteDataReference<T> dataReference)

--- a/GlogGenerator.Test/Data/SiteDataIndexTests.cs
+++ b/GlogGenerator.Test/Data/SiteDataIndexTests.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using GlogGenerator.Data;
 using GlogGenerator.IgdbApi;
 using Microsoft.Extensions.Logging;
@@ -10,6 +12,18 @@ namespace GlogGenerator.Test.Data
     [TestClass]
     public class SiteDataIndexTests
     {
+        private static bool IsDefaultTagData(TagData tagData)
+        {
+            var igdbGameCategories = (IgdbGameCategory[])Enum.GetValues(typeof(IgdbGameCategory));
+            var igdbGameCategoryDescriptions = igdbGameCategories.Where(c => c != IgdbGameCategory.None).Select(c => c.Description());
+            if (igdbGameCategoryDescriptions.Contains(tagData.Name))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
         [TestMethod]
         public void TestLoadContentMergedTags()
         {
@@ -65,7 +79,7 @@ namespace GlogGenerator.Test.Data
             Assert.AreEqual(0, logger.GetLogs(LogLevel.Error).Count);
             Assert.AreEqual(0, logger.GetLogs(LogLevel.Warning).Count);
 
-            var testReference = new SiteDataReference<GameData>("Some Game Name");
+            var testReference = testIndex.CreateReference<GameData>(testDataItem.Name, true);
             var testData = testIndex.GetData(testReference);
 
             Assert.IsTrue(testReference.GetIsResolved());
@@ -110,6 +124,9 @@ namespace GlogGenerator.Test.Data
             Assert.AreEqual(0, logger.GetLogs(LogLevel.Error).Count);
             Assert.AreEqual(0, logger.GetLogs(LogLevel.Warning).Count);
 
+            testIndex.CreateReference<PlatformData>(testPlatformOld.Abbreviation, true);
+            testIndex.ResolveReferences();
+
             var testPlatformNew = new IgdbPlatform() { Id = 1, Abbreviation = "PSOne" };
 
             mockIgdbCache.GetAllPlatforms().Returns(new List<IgdbPlatform>() { testPlatformNew });
@@ -145,6 +162,9 @@ namespace GlogGenerator.Test.Data
             Assert.AreEqual(0, logger.GetLogs(LogLevel.Error).Count);
             Assert.AreEqual(0, logger.GetLogs(LogLevel.Warning).Count);
 
+            testIndex.CreateReference<PlatformData>(testPlatformOld.Abbreviation, true);
+            testIndex.ResolveReferences();
+
             mockIgdbCache.GetAllPlatforms().Returns(new List<IgdbPlatform>());
 
             testIndex.LoadContent(mockIgdbCache, builder.GetMarkdownPipeline(), includeDrafts: false);
@@ -178,7 +198,10 @@ namespace GlogGenerator.Test.Data
             Assert.AreEqual(0, logger.GetLogs(LogLevel.Error).Count);
             Assert.AreEqual(0, logger.GetLogs(LogLevel.Warning).Count);
 
-            var testPlatformNew = new IgdbPlatform() { Id = 2, Abbreviation = "PS1" };
+            testIndex.CreateReference<PlatformData>(testPlatformOld.Abbreviation, true);
+            testIndex.ResolveReferences();
+
+            var testPlatformNew = new IgdbPlatform() { Id = 2, Abbreviation = testPlatformOld.Abbreviation };
 
             mockIgdbCache.GetAllPlatforms().Returns(new List<IgdbPlatform>() { testPlatformNew });
 
@@ -191,6 +214,51 @@ namespace GlogGenerator.Test.Data
 
             var expectedMessage = $"Updated data index has a different data ID for PlatformData with key {testPlatformOld.GetReferenceString(mockIgdbCache)}: old data ID {testPlatformOld.GetUniqueIdString(mockIgdbCache)} new data ID {testPlatformNew.GetUniqueIdString(mockIgdbCache)}";
             Assert.AreEqual(expectedMessage, warnings[0].Message);
+        }
+
+        [TestMethod]
+        public void TestLoadContentUpdateNonContentReferenceChanged()
+        {
+            var logger = new TestLogger();
+
+            var testCompany = new IgdbCompany() { Id = 1234, Name = "The Developer" };
+            var testInvolvedCompany = new IgdbInvolvedCompany() { Id = 5678, CompanyId = testCompany.Id };
+            var testGame = new IgdbGame()
+            {
+                Id = 1,
+                Name = "Video Game",
+                InvolvedCompanyIds = new List<int>() { testInvolvedCompany.Id },
+            };
+
+            var mockIgdbCache = Substitute.For<IIgdbCache>();
+            mockIgdbCache.GetAllGames().Returns(new List<IgdbGame>() { testGame });
+            mockIgdbCache.GetAllPlatforms().Returns(new List<IgdbPlatform>());
+            mockIgdbCache.GetAllGameMetadata().Returns(new List<IgdbEntity>() { testCompany });
+
+            var testIndex = new SiteDataIndex(logger, string.Empty);
+            var builder = new SiteBuilder(logger, new ConfigData(), testIndex);
+
+            testIndex.LoadContent(mockIgdbCache, builder.GetMarkdownPipeline(), includeDrafts: false);
+
+            Assert.AreEqual(0, logger.GetLogs(LogLevel.Error).Count);
+            Assert.AreEqual(0, logger.GetLogs(LogLevel.Warning).Count);
+
+            var indexTags = testIndex.GetTags().Where(t => !IsDefaultTagData(t)).ToList();
+            Assert.AreEqual(1, indexTags.Count);
+            Assert.AreEqual(testCompany.Name, indexTags[0].Name);
+
+            var testCompanyUpdated = new IgdbCompany() { Id = testCompany.Id, Name = "The Updated Developer" };
+
+            mockIgdbCache.GetAllGameMetadata().Returns(new List<IgdbEntity>() { testCompanyUpdated });
+
+            testIndex.LoadContent(mockIgdbCache, builder.GetMarkdownPipeline(), includeDrafts: false);
+
+            Assert.AreEqual(0, logger.GetLogs(LogLevel.Error).Count);
+            Assert.AreEqual(0, logger.GetLogs(LogLevel.Warning).Count);
+
+            indexTags = testIndex.GetTags().Where(t => !IsDefaultTagData(t)).ToList();
+            Assert.AreEqual(1, indexTags.Count);
+            Assert.AreEqual(testCompanyUpdated.Name, indexTags[0].Name);
         }
     }
 }

--- a/GlogGenerator.Test/MarkdownExtensions/GlogLinkTests.cs
+++ b/GlogGenerator.Test/MarkdownExtensions/GlogLinkTests.cs
@@ -53,22 +53,25 @@ namespace GlogGenerator.Test.MarkdownExtensions
                 }
             }
 
-            mockSiteDataIndex.CreateReference<GameData>(Arg.Any<string>()).Returns(args =>
+            mockSiteDataIndex.CreateReference<GameData>(Arg.Any<string>(), Arg.Any<bool>()).Returns(args =>
             {
                 var referenceKey = args.ArgAt<string>(0);
-                return new SiteDataReference<GameData>(referenceKey);
+                var shouldUpdateOnDataChange = args.ArgAt<bool>(1);
+                return new SiteDataReference<GameData>(referenceKey, shouldUpdateOnDataChange);
             });
 
-            mockSiteDataIndex.CreateReference<PlatformData>(Arg.Any<string>()).Returns(args =>
+            mockSiteDataIndex.CreateReference<PlatformData>(Arg.Any<string>(), Arg.Any<bool>()).Returns(args =>
             {
                 var referenceKey = args.ArgAt<string>(0);
-                return new SiteDataReference<PlatformData>(referenceKey);
+                var shouldUpdateOnDataChange = args.ArgAt<bool>(1);
+                return new SiteDataReference<PlatformData>(referenceKey, shouldUpdateOnDataChange);
             });
 
-            mockSiteDataIndex.CreateReference<TagData>(Arg.Any<string>()).Returns(args =>
+            mockSiteDataIndex.CreateReference<TagData>(Arg.Any<string>(), Arg.Any<bool>()).Returns(args =>
             {
                 var referenceKey = args.ArgAt<string>(0);
-                return new SiteDataReference<TagData>(referenceKey);
+                var shouldUpdateOnDataChange = args.ArgAt<bool>(1);
+                return new SiteDataReference<TagData>(referenceKey, shouldUpdateOnDataChange);
             });
 
             mockSiteDataIndex.GetData<GameData>(Arg.Any<SiteDataReference<GameData>>()).Returns(args =>

--- a/GlogGenerator.Test/SmallSiteTest.cs
+++ b/GlogGenerator.Test/SmallSiteTest.cs
@@ -38,7 +38,6 @@ namespace GlogGenerator.Test
             builder.UpdateDataIndex();
 
             builder.ResolveDataReferences();
-
             builder.UpdateContentRoutes();
 
             // Ensure the output directory is clean, first.
@@ -95,6 +94,7 @@ namespace GlogGenerator.Test
             builder.ResolveDataReferences();
             builder.UpdateDataIndex();
 
+            builder.ResolveDataReferences();
             builder.UpdateContentRoutes();
 
             // Ensure the output directory is clean, first.

--- a/GlogGenerator/Data/GameData.cs
+++ b/GlogGenerator/Data/GameData.cs
@@ -68,7 +68,7 @@ namespace GlogGenerator.Data
                 game.Tags.Add(categoryString);
 
                 // Register a data reference to the category, so the data index knows it is in-use (and won't delete it).
-                siteDataIndex.CreateReference<TagData>(categoryString);
+                siteDataIndex.CreateReference<TagData>(categoryString, false);
             }
 
             if (!string.IsNullOrEmpty(igdbGame.Url))
@@ -254,7 +254,7 @@ namespace GlogGenerator.Data
                     }
 
                     // Register a data reference to the tag, so the data index knows it is in-use (and won't delete it).
-                    siteDataIndex.CreateReference<TagData>(tagReferenceString);
+                    siteDataIndex.CreateReference<TagData>(tagReferenceString, false);
                 }
             }
         }
@@ -269,7 +269,7 @@ namespace GlogGenerator.Data
                     this.RelatedGames.Add(relatedGame.GetReferenceString(igdbCache));
 
                     // Register a data reference to the related game, so the data index knows it is in-use (and won't delete it).
-                    siteDataIndex.CreateReference<GameData>(relatedGame.GetReferenceString(igdbCache));
+                    siteDataIndex.CreateReference<GameData>(relatedGame.GetReferenceString(igdbCache), false);
                 }
             }
         }

--- a/GlogGenerator/Data/ISiteDataIndex.cs
+++ b/GlogGenerator/Data/ISiteDataIndex.cs
@@ -4,7 +4,7 @@ namespace GlogGenerator.Data
 {
     public interface ISiteDataIndex
     {
-        public SiteDataReference<T> CreateReference<T>(string referenceKey)
+        public SiteDataReference<T> CreateReference<T>(string referenceKey, bool shouldUpdateOnDataChange)
             where T : IGlogReferenceable;
 
         public T GetData<T>(SiteDataReference<T> dataReference)

--- a/GlogGenerator/Data/ISiteDataReference.cs
+++ b/GlogGenerator/Data/ISiteDataReference.cs
@@ -9,5 +9,7 @@ namespace GlogGenerator.Data
         public string GetResolvedReferenceId();
 
         public void SetData(IGlogReferenceable data);
+
+        public bool GetShouldUpdateOnDataChange();
     }
 }

--- a/GlogGenerator/Data/PostData.cs
+++ b/GlogGenerator/Data/PostData.cs
@@ -194,7 +194,7 @@ namespace GlogGenerator.Data
                 {
                     foreach (var categoryName in frontMatterCategories)
                     {
-                        var categoryReference = siteDataIndex.CreateReference<CategoryData>(categoryName.ToString());
+                        var categoryReference = siteDataIndex.CreateReference<CategoryData>(categoryName.ToString(), true);
 
                         var frontMatterReference = Tuple.Create(categoryName as Tommy.TomlString, categoryReference);
                         post.categories.Add(frontMatterReference);
@@ -205,7 +205,7 @@ namespace GlogGenerator.Data
                 {
                     foreach (var gameTitle in frontMatterGames)
                     {
-                        var gameReference = siteDataIndex.CreateReference<GameData>(gameTitle.ToString());
+                        var gameReference = siteDataIndex.CreateReference<GameData>(gameTitle.ToString(), true);
 
                         var frontMatterReference = Tuple.Create(gameTitle as Tommy.TomlString, gameReference);
                         post.games.Add(frontMatterReference);
@@ -216,7 +216,7 @@ namespace GlogGenerator.Data
                 {
                     foreach (var platformAbbreviation in frontMatterPlatforms)
                     {
-                        var platformReference = siteDataIndex.CreateReference<PlatformData>(platformAbbreviation.ToString());
+                        var platformReference = siteDataIndex.CreateReference<PlatformData>(platformAbbreviation.ToString(), true);
 
                         var frontMatterReference = Tuple.Create(platformAbbreviation as Tommy.TomlString, platformReference);
                         post.platforms.Add(frontMatterReference);
@@ -227,7 +227,7 @@ namespace GlogGenerator.Data
                 {
                     foreach (var ratingName in frontMatterRatings)
                     {
-                        var ratingReference = siteDataIndex.CreateReference<RatingData>(ratingName.ToString());
+                        var ratingReference = siteDataIndex.CreateReference<RatingData>(ratingName.ToString(), true);
 
                         var frontMatterReference = Tuple.Create(ratingName as Tommy.TomlString, ratingReference);
                         post.ratings.Add(frontMatterReference);

--- a/GlogGenerator/Data/SiteDataReference.cs
+++ b/GlogGenerator/Data/SiteDataReference.cs
@@ -7,11 +7,16 @@ namespace GlogGenerator.Data
     {
         private string unresolvedReferenceKey = null;
         private string resolvedReferenceId = null;
+        private bool shouldUpdateOnDataChange = true;
 
-        public SiteDataReference(string referenceKey)
+        public SiteDataReference(string referenceKey, bool shouldUpdateOnDataChange)
         {
             this.unresolvedReferenceKey = referenceKey;
+            this.shouldUpdateOnDataChange = shouldUpdateOnDataChange;
         }
+
+        public SiteDataReference(string referenceKey)
+            : this(referenceKey, true) { }
 
         public bool GetIsResolved()
         {
@@ -37,6 +42,11 @@ namespace GlogGenerator.Data
             }
             
             this.unresolvedReferenceKey = null;
+        }
+
+        public bool GetShouldUpdateOnDataChange()
+        {
+            return this.shouldUpdateOnDataChange;
         }
     }
 }

--- a/GlogGenerator/MarkdownExtensions/GlogLinkInline.cs
+++ b/GlogGenerator/MarkdownExtensions/GlogLinkInline.cs
@@ -25,23 +25,23 @@ namespace GlogGenerator.MarkdownExtensions
                 switch (referenceTypeName)
                 {
                     case "category":
-                        this.dataReference = siteDataIndex.CreateReference<CategoryData>(referenceKey) as ISiteDataReference;
+                        this.dataReference = siteDataIndex.CreateReference<CategoryData>(referenceKey, true) as ISiteDataReference;
                         break;
 
                     case "game":
-                        this.dataReference = siteDataIndex.CreateReference<GameData>(referenceKey) as ISiteDataReference;
+                        this.dataReference = siteDataIndex.CreateReference<GameData>(referenceKey, true) as ISiteDataReference;
                         break;
 
                     case "platform":
-                        this.dataReference = siteDataIndex.CreateReference<PlatformData>(referenceKey) as ISiteDataReference;
+                        this.dataReference = siteDataIndex.CreateReference<PlatformData>(referenceKey, true) as ISiteDataReference;
                         break;
 
                     case "rating":
-                        this.dataReference = siteDataIndex.CreateReference<RatingData>(referenceKey) as ISiteDataReference;
+                        this.dataReference = siteDataIndex.CreateReference<RatingData>(referenceKey, true) as ISiteDataReference;
                         break;
 
                     case "tag":
-                        this.dataReference = siteDataIndex.CreateReference<TagData>(referenceKey) as ISiteDataReference;
+                        this.dataReference = siteDataIndex.CreateReference<TagData>(referenceKey, true) as ISiteDataReference;
                         break;
 
                     default:


### PR DESCRIPTION
Yesterday's tag-update fail was really due to two separate problems:

1. TagData isn't clearly correlated to original IgdbEntity IDs, and hence tag references aren't so straightforward to update when an IGDB tag string is modified.  ... but this has always been the case, and is difficult to un-tangle since TagData may map to *multiple* IgdbEntities, which may not even be updating consistently with one another.  (Should probably still fix that, but that's, eugh.)
2. Recent unreferenced-data-culling work had to include additional "throwaway" CreateReference() calls (i.e. new SiteDataIndex DataReference registrations) in order to avoid culling a Game's tags, even when those tags aren't explicitly referenced in content (such as posts).  This behavior of registering not-explicitly-referenced tag strings is new!

That second behavior, of treating all game-associated tags just like content-referenced tags, wasn't quite appropriate -- because when IGDB data is updated and SiteDataIndex is re-built, old tags which weren't explicitly referenced by name SHOULD be discarded! because attempting to update their reference strings wouldn't serve any purpose anyway.

So, now it's possible to add a DataReference to the SiteDataIndex which *will not* be updated in LoadContent(), and will instead be discarded (possibly replaced with new data, or possibly gone forever).  These should-not-update-on-data-change DataReferences only exist for the purpose of marking data as in-use, to avoid culling in RemoveUnreferencedData, so that they'll be used when generating site content / rendering post-list pages.