### PR TITLE
Use a GitHub App to authorize automatic data updates, and trigger regular workflows.

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -28,6 +28,13 @@ jobs:
           rm -rf public
           ./GlogGeneratorBuild/GlogGenerator build -i . -t GlogGeneratorBuild/templates -u true --igdb-client-id $TWITCH_CLIENT_ID --igdb-client-secret $TWITCH_CLIENT_SECRET -w true -h "https://tsuereth.com" -o public
 
+      - name: AuthorizeGlogAutoUpdateApp
+        uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ secrets.GLOG_AUTO_UPDATE_APP_ID }}
+          private-key: ${{ secrets.GLOG_AUTO_UPDATE_PRIVATE_KEY }}
+
       - name: SetupPullRequestValues
         run: |
           echo "GLOG_PR_BRANCH=autoupdate-$GITHUB_RUN_NUMBER.$GITHUB_RUN_ATTEMPT" >> "$GITHUB_ENV"
@@ -36,8 +43,8 @@ jobs:
       - name: CreatePullRequest
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          author: GitHub <noreply@github.com>
+          token: ${{ steps.app-token.outputs.token }}
+          sign-commits: true
           commit-message: ${{ env.GLOG_PR_DESCRIPTION }}
           title: ${{ env.GLOG_PR_DESCRIPTION }}
           body: ${{ env.GLOG_PR_DESCRIPTION }}


### PR DESCRIPTION
This "don't skip ci" attempt 5bb1d35e4d232194f846782966d938b8a9b86dae

Didn't do what I wanted; evidently any workflow that uses another workflow's `GITHUB_TOKEN` is forbidden from triggering subsequent `on: pull_request` actions, as an infinite recursion protection.

The create-pull-request action documents various approaches to work around this: https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs

Including how to implement a GitHub App for its auth flow: https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#authenticating-with-github-app-generated-tokens